### PR TITLE
Remove `icons:` from labels in PI

### DIFF
--- a/com.neil-enns.trackaudio.sdPlugin/station-status.html
+++ b/com.neil-enns.trackaudio.sdPlugin/station-status.html
@@ -21,21 +21,21 @@
       </sdpi-radio>
     </sdpi-item>
 
-    <sdpi-item label="Not listening icon">
+    <sdpi-item label="Not listening">
       <sdpi-file
         setting="notListeningIconPath"
         accept="image/png, image/jpeg"
       ></sdpi-file>
     </sdpi-item>
 
-    <sdpi-item label="Listening icon">
+    <sdpi-item label="Listening">
       <sdpi-file
         setting="listeningIconPath"
         accept="image/png, image/jpeg, image/svg+xml"
       ></sdpi-file>
     </sdpi-item>
 
-    <sdpi-item label="Active comms icon">
+    <sdpi-item label="Active comms">
       <sdpi-file
         setting="activeCommsIconPath"
         accept="image/png, image/jpeg, image/svg+xml"


### PR DESCRIPTION
Fixes #25