### PR TITLE
Buttons should reset to not listening state after trackaudio disconnected

### DIFF
--- a/src/actionManager.ts
+++ b/src/actionManager.ts
@@ -94,6 +94,16 @@ export default class ActionManager extends EventEmitter {
   }
 
   /**
+   * Sets the isListening state on all tracked actions.
+   * @param state The isListening state to set
+   */
+  public setIsListeningOnAll(isListening: boolean) {
+    this.getStationStatusActions().forEach((entry) => {
+      entry.isListening = isListening;
+    });
+  }
+
+  /**
    * Updates all actions that match the callsign to show the listen state.
    * @param callsign The callsign of the actions to update
    */
@@ -104,7 +114,6 @@ export default class ActionManager extends EventEmitter {
       )
       .forEach((entry) => {
         entry.isListening = true;
-        entry.setListeningImage();
       });
   }
 
@@ -119,7 +128,6 @@ export default class ActionManager extends EventEmitter {
       )
       .forEach((entry) => {
         entry.isListening = false;
-        entry.setListeningImage();
       });
   }
 
@@ -131,13 +139,10 @@ export default class ActionManager extends EventEmitter {
     this.getStationStatusActions()
       .filter(
         (entry) =>
-          entry.frequency === frequency &&
-          entry.settings.listenTo === "rx" &&
-          !entry.isRx
+          entry.frequency === frequency && entry.settings.listenTo === "rx"
       )
       .forEach((entry) => {
         entry.isRx = true;
-        entry.setActiveCommsImage();
       });
   }
 
@@ -149,13 +154,10 @@ export default class ActionManager extends EventEmitter {
     this.getStationStatusActions()
       .filter(
         (entry) =>
-          entry.frequency === frequency &&
-          entry.settings.listenTo === "rx" &&
-          entry.isRx
+          entry.frequency === frequency && entry.settings.listenTo === "rx"
       )
       .forEach((entry) => {
         entry.isRx = false;
-        entry.setActiveCommsImage();
       });
   }
 
@@ -167,13 +169,10 @@ export default class ActionManager extends EventEmitter {
     this.getStationStatusActions()
       .filter(
         (entry) =>
-          entry.frequency === frequency &&
-          entry.settings.listenTo === "tx" &&
-          !entry.isTx
+          entry.frequency === frequency && entry.settings.listenTo === "tx"
       )
       .forEach((entry) => {
         entry.isTx = true;
-        entry.setActiveCommsImage();
       });
   }
 
@@ -185,13 +184,10 @@ export default class ActionManager extends EventEmitter {
     this.getStationStatusActions()
       .filter(
         (entry) =>
-          entry.frequency === frequency &&
-          entry.settings.listenTo === "tx" &&
-          entry.isTx
+          entry.frequency === frequency && entry.settings.listenTo === "tx"
       )
       .forEach((entry) => {
         entry.isTx = false;
-        entry.setActiveCommsImage();
       });
   }
 
@@ -221,7 +217,6 @@ export default class ActionManager extends EventEmitter {
       }
 
       entry.isConnected = isConnected;
-      entry.setConnectedImage();
     });
   }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -97,6 +97,7 @@ trackAudio.on("connected", () => {
 trackAudio.on("disconnected", () => {
   console.log("Plugin detected loss of connection to TrackAudio");
   actionManager.setTrackAudioConnectionState(trackAudio.isConnected());
+  actionManager.setIsListeningOnAll(false);
 });
 
 trackAudio.on("frequencyUpdate", (data: FrequenciesUpdate) => {

--- a/src/stationStatusAction.ts
+++ b/src/stationStatusAction.ts
@@ -29,9 +29,10 @@ export class StationStatusAction {
   type = "StationStatusAction";
   action: Action;
   frequency = 0;
-  isRx = false;
-  isTx = false;
-  isListening = false;
+
+  private _isRx = false;
+  private _isTx = false;
+  private _isListening = false;
 
   settings: StationStatusActionSettings = new StationStatusActionSettings();
 
@@ -47,6 +48,67 @@ export class StationStatusAction {
     this.settings.notListeningIconPath = options.notListeningIconPath;
     this.settings.listeningIconPath = options.listeningIconPath;
     this.settings.activeCommsIconPath = options.activeCommsIconPath;
+  }
+
+  // Getters and setters
+  /**
+   * True if the station is actively receiveing.
+   */
+  get isRx() {
+    return this._isRx;
+  }
+
+  /**
+   * Sets the isRx property and updates the action image accordingly.
+   */
+  set isRx(newValue: boolean) {
+    // Don't do anything if the state is the same
+    if (this._isRx === newValue) {
+      return;
+    }
+
+    this._isRx = newValue;
+    this.setActiveCommsImage();
+  }
+
+  /**
+   * True if the station is actively transmitting.
+   */
+  get isTx() {
+    return this._isTx;
+  }
+
+  /**
+   * Sets the isTx property and updates the action image accordingly.
+   */
+  set isTx(newValue: boolean) {
+    // Don't do anything if the state is the same
+    if (this._isTx === newValue) {
+      return;
+    }
+
+    this._isTx = newValue;
+    this.setActiveCommsImage();
+  }
+
+  /**
+   * True if the station is being listened to.
+   */
+  get isListening() {
+    return this._isListening;
+  }
+
+  /**
+   * Sets the isListening property and updates the action image accordingly.
+   */
+  set isListening(newValue: boolean) {
+    // Don't do anything if the state is the same
+    if (this._isListening === newValue) {
+      return;
+    }
+
+    this._isListening = newValue;
+    this.setListeningImage();
   }
 
   /**

--- a/src/trackAudioStatusAction.ts
+++ b/src/trackAudioStatusAction.ts
@@ -8,7 +8,8 @@ import { StatusAction } from "./actionManager";
 export class TrackAudioStatusAction {
   type = "trackAudioStatusAction";
   action: Action;
-  isConnected = false;
+
+  private _isConnected = false;
 
   /**
    * Creates a new TrackAudioStatusAction.
@@ -18,6 +19,25 @@ export class TrackAudioStatusAction {
     this.action = action;
   }
 
+  /**
+   * Returns true when the connected state is displayed.
+   */
+  get isConnected() {
+    return this._isConnected;
+  }
+
+  /**
+   * Sets the isConnected state
+   */
+  set isConnected(newValue: boolean) {
+    // Don't do anything if the state is the same
+    if (this._isConnected === newValue) {
+      return;
+    }
+
+    this._isConnected = newValue;
+    this.setConnectedImage();
+  }
   /**
    * Sets the action image based on the isConnected state
    */


### PR DESCRIPTION
Fixes #34

Major refactor to use setters and getters on the state properties, and move changing the images inside each individual action instead of being in the actionmanager.