### PR TITLE
Add optional display of last received callsign to RX buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,15 @@ station status action like this:
 
 ### Station status settings
 
-| Setting       | Description                                                                                      |
-| ------------- | ------------------------------------------------------------------------------------------------ |
-| Callsign      | The callsign for the station you want to display status for. Required.                           |
-| Listen to     | What status to display on the button, either RX, TX, XC, or XCA. Required.                       |
-| Not listening | The image to display when the station is not currently active. Optional, defaults to black.      |
-| Listening     | The image to display when the station is active. Optional, defaults to green.                    |
-| Active comms  | The image to display when a transmission is actively taking place. Optional, defaults to orange. |
+| Setting                     | Description                                                                                                             |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Title                       | The title to show on the action. If omitted the station callsign and listen to value will be shown.                     |
+| Callsign                    | The callsign for the station you want to display status for. Required.                                                  |
+| Listen to                   | What status to display on the button, either RX, TX, XC, or XCA. Required.                                              |
+| Show last received callsign | When checked, the last received callsign will be appended to the action title. Only applies to actions listening to RX. |
+| Not listening               | The image to display when the station is not currently active. Optional, defaults to black.                             |
+| Listening                   | The image to display when the station is active. Optional, defaults to green.                                           |
+| Active comms                | The image to display when a transmission is actively taking place. Optional, defaults to orange.                        |
 
 ## Configuring a TrackAudio status action
 

--- a/com.neil-enns.trackaudio.sdPlugin/manifest.json
+++ b/com.neil-enns.trackaudio.sdPlugin/manifest.json
@@ -11,6 +11,7 @@
       "DisableAutomaticStates": true,
       "Controllers": ["Keypad"],
       "PropertyInspectorPath": "pi/stationStatus.html",
+      "UserTitleEnabled": false,
       "States": [
         {
           "Image": "images/actions/stationStatus/black",

--- a/com.neil-enns.trackaudio.sdPlugin/pi/stationStatus.html
+++ b/com.neil-enns.trackaudio.sdPlugin/pi/stationStatus.html
@@ -29,6 +29,13 @@
       </sdpi-radio>
     </sdpi-item>
 
+    <sdpi-item>
+      <sdpi-checkbox
+        setting="showLastReceivedCallsign"
+        label="Show last received callsign"
+      ></sdpi-checkbox>
+    </sdpi-item>
+
     <sdpi-item label="Not listening">
       <sdpi-file
         setting="notListeningIconPath"

--- a/com.neil-enns.trackaudio.sdPlugin/pi/stationStatus.html
+++ b/com.neil-enns.trackaudio.sdPlugin/pi/stationStatus.html
@@ -5,6 +5,13 @@
     <script src="https://cdn.jsdelivr.net/gh/geekyeggo/sdpi-components@v2/dist/sdpi-components.js"></script>
   </head>
   <body>
+    <sdpi-item label="Title">
+      <sdpi-textfield
+        setting="title"
+        placeholder="Optional title"
+      ></sdpi-textfield>
+    </sdpi-item>
+
     <sdpi-item label="Callsign">
       <sdpi-textfield
         setting="callsign"

--- a/src/actions/stationStatus.ts
+++ b/src/actions/stationStatus.ts
@@ -7,7 +7,6 @@ import {
   WillAppearEvent,
   WillDisappearEvent,
 } from "@elgato/streamdeck";
-import { getDisplayTitle } from "@helpers/helpers";
 import ActionManager from "@managers/action";
 
 @action({ UUID: "com.neil-enns.trackaudio.stationstatus" })
@@ -20,19 +19,6 @@ export class StationStatus extends SingletonAction<StationSettings> {
   // to something useful.
   onWillAppear(ev: WillAppearEvent<StationSettings>): void | Promise<void> {
     ActionManager.getInstance().addStation(ev.action, ev.payload.settings);
-
-    // Set the default title to the provided callsign. StreamDeck will use this if the user
-    // didn't specify a custom title.
-    ev.action
-      .setTitle(
-        getDisplayTitle(
-          ev.payload.settings.callsign,
-          ev.payload.settings.listenTo ?? "rx"
-        )
-      )
-      .catch((error: unknown) => {
-        console.error(error);
-      });
   }
 
   // When the action is removed from a profile it also gets removed from the ActionManager.
@@ -48,19 +34,6 @@ export class StationStatus extends SingletonAction<StationSettings> {
     ev: DidReceiveSettingsEvent<StationSettings>
   ): void | Promise<void> {
     ActionManager.getInstance().updateStation(ev.action, ev.payload.settings);
-
-    // Set the default title to the provided callsign. StreamDeck will use this if the user
-    // didn't specify a custom title.
-    ev.action
-      .setTitle(
-        getDisplayTitle(
-          ev.payload.settings.callsign,
-          ev.payload.settings.listenTo ?? "rx"
-        )
-      )
-      .catch((error: unknown) => {
-        console.error(error);
-      });
   }
 
   // When the key is pressed send the request to toggle the current action to the ActionManager.
@@ -72,6 +45,7 @@ export class StationStatus extends SingletonAction<StationSettings> {
 }
 
 export interface StationSettings {
+  title?: string;
   callsign: string;
   listenTo: ListenTo | null;
   notListeningIconPath: string | null;

--- a/src/actions/stationStatus.ts
+++ b/src/actions/stationStatus.ts
@@ -47,6 +47,7 @@ export class StationStatus extends SingletonAction<StationSettings> {
 export interface StationSettings {
   title?: string;
   callsign: string;
+  showLastReceivedCallsign: boolean;
   listenTo: ListenTo | null;
   notListeningIconPath: string | null;
   listeningIconPath: string | null;

--- a/src/controllers/stationStatus.ts
+++ b/src/controllers/stationStatus.ts
@@ -39,6 +39,13 @@ export class StationStatusController implements Controller {
 
   // Getters and setters
   /**
+   * Convenience property to get the showLastReceivedCallsign value of settings.
+   */
+  get showLastReceivedCallsign() {
+    return this._settings.showLastReceivedCallsign;
+  }
+
+  /**
    * Conveinence property to get the listenTo value of settings.
    */
   get listenTo() {
@@ -216,10 +223,11 @@ export class StationStatusController implements Controller {
   }
 
   /**
-   * Shows the title on the action.
+   * Shows the title on the action. Appends the last received callsign to
+   * the base title if it exists and showLastReceivedCallsign is enabled in settings.
    */
   public showTitle() {
-    if (this.lastReceivedCallsign) {
+    if (this.lastReceivedCallsign && this.showLastReceivedCallsign) {
       this.action
         .setTitle(`${this.title}\n\n${this.lastReceivedCallsign}`)
         .catch((error: unknown) => {

--- a/src/controllers/stationStatus.ts
+++ b/src/controllers/stationStatus.ts
@@ -33,6 +33,8 @@ export class StationStatusController implements Controller {
   constructor(action: Action, settings: StationSettings) {
     this.action = action;
     this._settings = settings;
+
+    this.showTitle();
   }
 
   // Getters and setters
@@ -48,6 +50,18 @@ export class StationStatusController implements Controller {
    */
   get callsign() {
     return this._settings.callsign;
+  }
+
+  /**
+   * Returns the title specified by the user in the property inspector,
+   * or the default title if no user title was specified.
+   */
+  get title() {
+    if (this._settings.title !== undefined && this._settings.title !== "") {
+      return this._settings.title;
+    } else {
+      return getDisplayTitle(this.callsign, this.listenTo);
+    }
   }
 
   /**
@@ -142,21 +156,7 @@ export class StationStatusController implements Controller {
   set lastReceivedCallsign(callsign: string | undefined) {
     this._lastReceivedcallsign = callsign;
 
-    const baseTitle = getDisplayTitle(this.callsign, this.listenTo);
-
-    if (this.lastReceivedCallsign) {
-      this.action
-        .setTitle(`${baseTitle}\n\n${this.lastReceivedCallsign}`)
-        .catch((error: unknown) => {
-          const err = error as Error;
-          console.error(`Unable to set action title: ${err.message}`);
-        });
-    } else {
-      this.action.setTitle(baseTitle).catch((error: unknown) => {
-        const err = error as Error;
-        console.error(`Unable to set action title: ${err.message}`);
-      });
-    }
+    this.showTitle();
   }
 
   /**
@@ -212,6 +212,25 @@ export class StationStatusController implements Controller {
         .catch((error: unknown) => {
           console.error(error);
         });
+    }
+  }
+
+  /**
+   * Shows the title on the action.
+   */
+  public showTitle() {
+    if (this.lastReceivedCallsign) {
+      this.action
+        .setTitle(`${this.title}\n\n${this.lastReceivedCallsign}`)
+        .catch((error: unknown) => {
+          const err = error as Error;
+          console.error(`Unable to set action title: ${err.message}`);
+        });
+    } else {
+      this.action.setTitle(this.title).catch((error: unknown) => {
+        const err = error as Error;
+        console.error(`Unable to set action title: ${err.message}`);
+      });
     }
   }
 }

--- a/src/eventHandlers/trackAudio/rxBegin.ts
+++ b/src/eventHandlers/trackAudio/rxBegin.ts
@@ -3,5 +3,8 @@ import ActionManager from "@managers/action";
 
 export const handleRxBegin = (data: RxBegin) => {
   console.log(`Receive started on: ${data.value.pFrequencyHz.toString()}`);
-  ActionManager.getInstance().rxBegin(data.value.pFrequencyHz);
+  ActionManager.getInstance().rxBegin(
+    data.value.pFrequencyHz,
+    data.value.callsign
+  );
 };

--- a/src/managers/action.ts
+++ b/src/managers/action.ts
@@ -110,7 +110,8 @@ export default class ActionManager extends EventEmitter {
 
     savedAction.settings = settings;
 
-    // Refreshes the icons in case that's what changed in settings
+    // Refreshes the title and icons in case that's what changed in settings
+    savedAction.showTitle();
     savedAction.setActiveCommsImage();
 
     if (requiresStationRefresh) {

--- a/src/managers/action.ts
+++ b/src/managers/action.ts
@@ -234,13 +234,14 @@ export default class ActionManager extends EventEmitter {
    * Updates all actions that match the frequency to show the transmission in progress state.
    * @param frequency The callsign of the actions to update
    */
-  public rxBegin(frequency: number) {
+  public rxBegin(frequency: number, callsign: string) {
     this.getStationStatusControllers()
       .filter(
         (entry) => entry.frequency === frequency && entry.listenTo === "rx"
       )
       .forEach((entry) => {
         entry.isReceiving = true;
+        entry.lastReceivedCallsign = callsign;
       });
 
     // Hotline actions that have a hotline frequency matching the rxBegin frequency


### PR DESCRIPTION
Fixes #93 

* Add a new setting to the station status action to display the last received callsign on the action
* Disable the default title from StreamDeck and add a custom one
* Update the documentation