### PR TITLE
Listen to xca should support last received callsign, tx, and rx

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,16 @@ configure the station status action like this to show that RX is enabled and the
 
 ### Station status settings <!-- omit from toc -->
 
-| Setting                     | Description                                                                                               | Default                                                         |
-| --------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| Title                       | The title to show on the action. Optional.                                                                | Station callsign and listen to value                            |
-| Callsign                    | The callsign for the station you want to display status for. Required.                                    |                                                                 |
-| Listen to                   | What status to display on the button, either RX, TX, or XCA. Required.                                    | RX                                                              |
-| Show last received callsign | When checked, the last received callsign will be appended to the action title. Only when listening to RX. | Disabled                                                        |
-| Not listening               | The image to display when the station is not currently active. Optional.                                  | ![Black background](docs/images/stationstatus-notlistening.png) |
-| Listening                   | The image to display when the station is active. Optional.                                                | ![Green background](docs/images/stationstatus-listening.png)    |
-| Active comms                | The image to display when a transmission is actively taking place. Optional.                              | ![Orange background](docs/images/stationstatus-receiving.png)   |
-| Unavailable                 | The image to display when the station is not added in TrackAudio. Optional, defaults to a warning icon.   | ![Warning icon](docs/images/stationstatus-unavailable.png)      |
+| Setting                     | Description                                                                                                                           | Default                                                         |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Title                       | The title to show on the action. Optional.                                                                                            | Station callsign and listen to value                            |
+| Callsign                    | The callsign for the station you want to display status for. Required.                                                                |                                                                 |
+| Listen to                   | What status to display on the button, either RX, TX, or XCA. Required.                                                                | RX                                                              |
+| Show last received callsign | When checked, the last received callsign will be appended to the action title. Only supported when listen to is set to `RX` or `XCA`. | Disabled                                                        |
+| Not listening               | The image to display when the station is not currently active. Optional.                                                              | ![Black background](docs/images/stationstatus-notlistening.png) |
+| Listening                   | The image to display when the station is active. Optional.                                                                            | ![Green background](docs/images/stationstatus-listening.png)    |
+| Active comms                | The image to display when a transmission is actively taking place. Optional.                                                          | ![Orange background](docs/images/stationstatus-receiving.png)   |
+| Unavailable                 | The image to display when the station is not added in TrackAudio. Optional, defaults to a warning icon.                               | ![Warning icon](docs/images/stationstatus-unavailable.png)      |
 
 ## Configuring a hotline action
 

--- a/com.neil-enns.trackaudio.sdPlugin/pi/stationStatus.html
+++ b/com.neil-enns.trackaudio.sdPlugin/pi/stationStatus.html
@@ -68,9 +68,10 @@
       document
         .querySelector('[setting="listenTo"]')
         .addEventListener("valuechange", function (ev) {
+          // Last receive callsign is only supported on rx and xca.
           document.querySelector(
             '[setting="showLastReceivedCallsign"]'
-          ).disabled = ev.target.value !== "rx";
+          ).disabled = !(ev.target.value === "rx" || ev.target.value === "xca");
         });
     </script>
   </body>

--- a/src/controllers/stationStatus.ts
+++ b/src/controllers/stationStatus.ts
@@ -52,6 +52,30 @@ export class StationStatusController implements Controller {
   }
 
   /**
+   * Returns true if listenTo is rx, xc, or xca, the settings that mean
+   * rx is active in TrackAudio.
+   */
+  get isListeningForReceive() {
+    return (
+      this._settings.listenTo === "rx" ||
+      this._settings.listenTo === "xc" ||
+      this._settings.listenTo === "xca"
+    );
+  }
+
+  /**
+   * Returns true if listenTo is tx, xc or xca, the settings that mean
+   * tx is active in TrackAudio.
+   */
+  get isListeningForTransmit() {
+    return (
+      this._settings.listenTo === "tx" ||
+      this._settings.listenTo === "xc" ||
+      this._settings.listenTo === "xca"
+    );
+  }
+
+  /**
    * Convenience property to get the callsign value of settings.
    */
   get callsign() {
@@ -261,7 +285,7 @@ export class StationStatusController implements Controller {
     if (
       this.lastReceivedCallsign &&
       this.showLastReceivedCallsign &&
-      this.listenTo === "rx"
+      this.isListeningForReceive
     ) {
       this.action
         .setTitle(`${this.title}\n${this.lastReceivedCallsign}`)

--- a/src/managers/action.ts
+++ b/src/managers/action.ts
@@ -379,7 +379,7 @@ export default class ActionManager extends EventEmitter {
   public rxBegin(frequency: number, callsign: string) {
     this.getStationStatusControllers()
       .filter(
-        (entry) => entry.frequency === frequency && entry.listenTo === "rx"
+        (entry) => entry.frequency === frequency && entry.isListeningForReceive
       )
       .forEach((entry) => {
         entry.isReceiving = true;
@@ -402,7 +402,7 @@ export default class ActionManager extends EventEmitter {
   public rxEnd(frequency: number) {
     this.getStationStatusControllers()
       .filter(
-        (entry) => entry.frequency === frequency && entry.listenTo === "rx"
+        (entry) => entry.frequency === frequency && entry.isListeningForReceive
       )
       .forEach((entry) => {
         entry.isReceiving = false;
@@ -423,7 +423,7 @@ export default class ActionManager extends EventEmitter {
    */
   public txBegin() {
     this.getStationStatusControllers()
-      .filter((entry) => entry.listenTo === "tx" || entry.listenTo === "xc")
+      .filter((entry) => entry.isListeningForTransmit)
       .forEach((entry) => {
         entry.isTransmitting = true;
       });
@@ -438,7 +438,7 @@ export default class ActionManager extends EventEmitter {
    */
   public txEnd() {
     this.getStationStatusControllers()
-      .filter((entry) => entry.listenTo === "tx" || entry.listenTo === "xc")
+      .filter((entry) => entry.isListeningForTransmit)
       .forEach((entry) => {
         entry.isTransmitting = false;
       });


### PR DESCRIPTION
Fixes #148

Setting listen to `xca` will now show last received callsign, and light up for both tx and rx.