### PR TITLE
Clear the frequency when the callsign changes

### DIFF
--- a/src/controllers/atisLetter.ts
+++ b/src/controllers/atisLetter.ts
@@ -22,7 +22,7 @@ const defaultUnavailableTemplatePath =
 export class AtisLetterController extends BaseController {
   type = "AtisLetterController";
 
-  private _settings!: AtisLetterSettings;
+  private _settings: AtisLetterSettings | null = null;
   private _letter?: string;
   private _isUpdated = false;
   private _isUnavailable = false;
@@ -78,7 +78,7 @@ export class AtisLetterController extends BaseController {
    * Returns the callsign for the ATIS action.
    */
   get callsign() {
-    return this._settings.callsign;
+    return this.settings.callsign;
   }
 
   /**
@@ -130,20 +130,24 @@ export class AtisLetterController extends BaseController {
    * Returns the showTitle setting, or true if undefined.
    */
   get showTitle() {
-    return this._settings.showTitle ?? true;
+    return this.settings.showTitle ?? true;
   }
 
   /**
    * Returns the showLetter setting, or true if undefined.
    */
   get showLetter() {
-    return this._settings.showLetter ?? true;
+    return this.settings.showLetter ?? true;
   }
 
   /**
    * Gets the settings.
    */
   get settings() {
+    if (this._settings === null) {
+      throw new Error("Settings not initialized. This should never happen.");
+    }
+
     return this._settings;
   }
 
@@ -211,7 +215,7 @@ export class AtisLetterController extends BaseController {
    * Convenience method to return the action's title from settings.
    */
   get title() {
-    return this._settings.title;
+    return this.settings.title;
   }
   //#endregion
 

--- a/src/controllers/hotline.ts
+++ b/src/controllers/hotline.ts
@@ -24,7 +24,7 @@ const defaultUnavailableTemplatePath = "images/actions/hotline/unavailable.svg";
 export class HotlineController extends BaseController {
   type = "HotlineController";
 
-  private _settings!: HotlineSettings;
+  private _settings: HotlineSettings | null = null;
 
   private _primaryFrequency = 0;
   private _hotlineFrequency = 0;
@@ -74,7 +74,7 @@ export class HotlineController extends BaseController {
    * if it is undefined.
    */
   get title() {
-    return this._settings.title ?? "HOTLINE";
+    return this.settings.title ?? "HOTLINE";
   }
 
   /**
@@ -296,41 +296,45 @@ export class HotlineController extends BaseController {
    * Convenience property to get the primaryCallsign value of settings.
    */
   get primaryCallsign() {
-    return this._settings.primaryCallsign;
+    return this.settings.primaryCallsign;
   }
 
   /**
    * Convenience property to get the hotlineCallsign value of settings.
    */
   get hotlineCallsign() {
-    return this._settings.hotlineCallsign;
+    return this.settings.hotlineCallsign;
   }
 
   /**
    * Returns the showTitle setting, or true if undefined.
    */
   get showTitle() {
-    return this._settings.showTitle ?? true;
+    return this.settings.showTitle ?? true;
   }
 
   /**
    * Returns the showHotlineCallsign setting, or false if undefined.
    */
   get showHotlineCallsign() {
-    return this._settings.showHotlineCallsign ?? false;
+    return this.settings.showHotlineCallsign ?? false;
   }
 
   /**
    * Returns the showPrimaryCallsign setting, or false if undefined.
    */
   get showPrimaryCallsign() {
-    return this._settings.showPrimaryCallsign ?? false;
+    return this.settings.showPrimaryCallsign ?? false;
   }
 
   /**
    * Gets the settings.
    */
   get settings() {
+    if (this._settings === null) {
+      throw new Error("Settings not initialized. This should never happen.");
+    }
+
     return this._settings;
   }
 
@@ -338,6 +342,22 @@ export class HotlineController extends BaseController {
    * Sets the settings.
    */
   set settings(newValue: HotlineSettings) {
+    // Issue 183: Clear the frequency if the callsign changes.
+    // The first time this gets set the _settings will be null so skip the check.
+    if (
+      this._settings &&
+      this._settings.primaryCallsign !== newValue.primaryCallsign
+    ) {
+      this.primaryFrequency = 0;
+    }
+
+    if (
+      this._settings &&
+      this._settings.hotlineCallsign !== newValue.hotlineCallsign
+    ) {
+      this.hotlineFrequency = 0;
+    }
+
     this._settings = newValue;
 
     this.bothActiveImagePath = newValue.bothActiveImagePath;

--- a/src/controllers/pushToTalk.ts
+++ b/src/controllers/pushToTalk.ts
@@ -19,7 +19,7 @@ const defaultTemplatePath = "images/actions/pushToTalk/template.svg";
 export class PushToTalkController extends BaseController {
   type = "PushToTalkController";
 
-  private _settings!: PushToTalkSettings;
+  private _settings: PushToTalkSettings | null = null;
   private _isTransmitting = false;
 
   private _notTransmittingImagePath?: string;
@@ -76,14 +76,14 @@ export class PushToTalkController extends BaseController {
    * Convenience method to return the action's title from settings.
    */
   get title() {
-    return this._settings.title;
+    return this.settings.title;
   }
 
   /**
    * Returns the showTitle setting, or false if undefined.
    */
   get showTitle() {
-    return this._settings.showTitle ?? false;
+    return this.settings.showTitle ?? false;
   }
 
   /**
@@ -110,6 +110,10 @@ export class PushToTalkController extends BaseController {
    * Gets the settings.
    */
   get settings() {
+    if (this._settings === null) {
+      throw new Error("Settings not initialized. This should never happen.");
+    }
+
     return this._settings;
   }
 

--- a/src/controllers/stationStatus.ts
+++ b/src/controllers/stationStatus.ts
@@ -27,7 +27,7 @@ const defaultUnavailableTemplatePath =
 export class StationStatusController extends BaseController {
   type = "StationStatusController";
 
-  private _settings!: StationSettings;
+  private _settings: StationSettings | null = null;
   private _frequency = 0;
   private _isReceiving = false;
   private _isTransmitting = false;
@@ -151,7 +151,7 @@ export class StationStatusController extends BaseController {
    * Conveinence property to get the listenTo value of settings.
    */
   get listenTo() {
-    return this._settings.listenTo ?? "rx";
+    return this.settings.listenTo ?? "rx";
   }
 
   /**
@@ -182,55 +182,59 @@ export class StationStatusController extends BaseController {
    * Convenience property to get the callsign value of settings.
    */
   get callsign() {
-    return this._settings.callsign;
+    return this.settings.callsign;
   }
 
   /**
    * Returns the title specified by the user in the property inspector.
    */
   get title() {
-    return this._settings.title;
+    return this.settings.title;
   }
 
   /**
    * Returns the showTitle setting, or true if undefined.
    */
   get showTitle() {
-    return this._settings.showTitle ?? true;
+    return this.settings.showTitle ?? true;
   }
 
   /**
    * Returns the showCallsign setting, or false if undefined.
    */
   get showCallsign() {
-    return this._settings.showCallsign ?? false;
+    return this.settings.showCallsign ?? false;
   }
 
   /**
    * Returns the showListenTo setting, or false if undefined
    */
   get showListenTo() {
-    return this._settings.showListenTo ?? false;
+    return this.settings.showListenTo ?? false;
   }
 
   /**
    * Returns the showFrequency setting, or false if undefined
    */
   get showFrequency() {
-    return this._settings.showFrequency ?? false;
+    return this.settings.showFrequency ?? false;
   }
 
   /**
    * Returns the showLastReceivedCallsign setting, or true if undefined
    */
   get showLastReceivedCallsign() {
-    return this._settings.showLastReceivedCallsign ?? true;
+    return this.settings.showLastReceivedCallsign ?? true;
   }
 
   /**
    * Gets the settings.
    */
   get settings() {
+    if (this._settings === null) {
+      throw new Error("Settings not initialized. This should never happen.");
+    }
+
     return this._settings;
   }
 
@@ -238,6 +242,11 @@ export class StationStatusController extends BaseController {
    * Sets the settings.
    */
   set settings(newValue: StationSettings) {
+    // Issue 183: Clear the frequency if the callsign changes.
+    if (this._settings && this._settings.callsign !== newValue.callsign) {
+      this.frequency = 0;
+    }
+
     this._settings = newValue;
 
     this.activeCommsImagePath = newValue.activeCommsImagePath;

--- a/src/controllers/trackAudioStatus.ts
+++ b/src/controllers/trackAudioStatus.ts
@@ -22,7 +22,7 @@ export class TrackAudioStatusController extends BaseController {
 
   private _isConnected = false;
   private _isVoiceConnected = false;
-  private _settings!: TrackAudioStatusSettings;
+  private _settings: TrackAudioStatusSettings | null = null;
 
   private _notConnectedImagePath?: string;
   private _connectedImagePath?: string;
@@ -47,14 +47,14 @@ export class TrackAudioStatusController extends BaseController {
    * Returns the showTitle setting, or false if undefined.
    */
   get showTitle() {
-    return this._settings.showTitle ?? false;
+    return this.settings.showTitle ?? false;
   }
 
   /**
    * Convenience method to return the action's title from settings.
    */
   get title() {
-    return this._settings.title;
+    return this.settings.title;
   }
 
   /**
@@ -106,6 +106,10 @@ export class TrackAudioStatusController extends BaseController {
    * Gets the settings.
    */
   get settings() {
+    if (this._settings === null) {
+      throw new Error("Settings not initialized. This should never happen.");
+    }
+
     return this._settings;
   }
 


### PR DESCRIPTION
Fixes #183

* Change how settings are initialized: set to null, then use getter everywhere that throws an exception if it is still null
* Clear the frequency when the callsigns change on station status and hotline actions 