### PR TITLE
Ensure TrackAudio status shows correctly when initially added to a profile

### DIFF
--- a/src/eventHandlers/action/trackAudioStatusAdded.ts
+++ b/src/eventHandlers/action/trackAudioStatusAdded.ts
@@ -1,9 +1,6 @@
 import actionManager from "@managers/action";
-import trackAudioManager from "@managers/trackAudio";
 
 export const handleTrackAudioStatusAdded = () => {
-  if (trackAudioManager.isConnected) {
-    // Refresh the button state so the new button gets the proper state from the start.
-    actionManager.setTrackAudioConnectionState(trackAudioManager.isConnected);
-  }
+  // Refresh the button state so the new button gets the proper state from the start.
+  actionManager.updateTrackAudioConnectionState();
 };

--- a/src/eventHandlers/trackAudio/connected.ts
+++ b/src/eventHandlers/trackAudio/connected.ts
@@ -2,6 +2,6 @@ import actionManager from "@managers/action";
 import trackAudioManager from "@managers/trackAudio";
 
 export const handleConnected = () => {
-  actionManager.setTrackAudioConnectionState(trackAudioManager.isConnected);
+  actionManager.updateTrackAudioConnectionState();
   trackAudioManager.refreshVoiceConnectedState(); // This will force an update of station states as well if voice is connected.
 };

--- a/src/eventHandlers/trackAudio/voiceConnectedState.ts
+++ b/src/eventHandlers/trackAudio/voiceConnectedState.ts
@@ -4,8 +4,9 @@ import trackAudioManager from "@managers/trackAudio";
 import vatsimManager from "@managers/vatsim";
 
 export const handleVoiceConnectedState = (data: VoiceConnectedState) => {
+  actionManager.updateTrackAudioConnectionState();
+
   if (data.value.connected) {
-    actionManager.setTrackAudioVoiceConnectedState(true);
     trackAudioManager.refreshStationStates();
 
     // Only start polling VATSIM if there are ATIS letters.
@@ -14,7 +15,6 @@ export const handleVoiceConnectedState = (data: VoiceConnectedState) => {
     }
   } else {
     actionManager.resetAllButTrackAudio();
-    actionManager.setTrackAudioVoiceConnectedState(false);
     vatsimManager.stop();
   }
 };

--- a/src/managers/action.ts
+++ b/src/managers/action.ts
@@ -585,29 +585,14 @@ class ActionManager extends EventEmitter {
   }
 
   /**
-   * Sets the connection state on all VectorAudio status buttons to the specified state
+   * Updates the connection state on all TrackAudio status buttons to the current connected states
    * and updates the background image to the appropriate state image.
    * @param isConnected True if connected, false if not
    */
-  public setTrackAudioConnectionState(isConnected: boolean) {
+  public updateTrackAudioConnectionState() {
     this.getTrackAudioStatusControllers().forEach((entry) => {
-      // Don't do anything if the state didn't change. This prevents repeated unnecessary updates
-      // when no connection is available and there's a reconnect attempt every 5 seconds.
-      if (entry.isConnected === isConnected) {
-        return;
-      }
-
-      entry.isConnected = isConnected;
-    });
-  }
-
-  public setTrackAudioVoiceConnectedState(isVoiceConnected: boolean) {
-    this.getTrackAudioStatusControllers().forEach((entry) => {
-      if (entry.isVoiceConnected === isVoiceConnected) {
-        return;
-      }
-
-      entry.isVoiceConnected = isVoiceConnected;
+      entry.isConnected = trackAudioManager.isConnected;
+      entry.isVoiceConnected = trackAudioManager.isVoiceConnected;
     });
   }
 


### PR DESCRIPTION
Fixes #201

* Clean up how the `isConnected` and `isVoiceConnected` properties get set.