### PR TITLE
Make long press on any action refresh that action's state

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ After installation the plugin actions are available under the TrackAudio categor
 The station status action displays the current status of a single station's button in TrackAudio, including
 whether communication is currently active. Pressing the action will toggle the equivalent button in TrackAudio,
 convenient for listening to other frequencies while controlling with the ability to quickly turn off listening
-to those frequencies when things get busy.
+to those frequencies when things get busy. A long press of the action will refresh the action's state.
 
 For example, if you are controlling `LMT_TWR` and have TrackAudio set up like this:
 
@@ -79,6 +79,7 @@ be added with `XCA` enabled and the hotline station should be added with `RX` en
 hotline action with the primary and hotline station callsigns.
 
 Once configured, pressing the action will toggle `TX` active between your primary and hotline frequencies.
+A long press of the action will refresh the action's state.
 
 ### Hotline action settings <!-- omit from toc -->
 
@@ -99,7 +100,8 @@ Once configured, pressing the action will toggle `TX` active between your primar
 ## Configuring a TrackAudio status action
 
 The TrackAudio status action shows the status of the connection between StreamDeck and TrackAudio, and whether
-the voice connection in TrackAudio is up. Pressing the action will force a state refresh.
+the voice connection in TrackAudio is up. A long press of the action will force a refresh of all the StreamDeck
+TrackAudio actions.
 
 ### TrackAudio status action settings <!-- omit from toc -->
 
@@ -118,7 +120,7 @@ the voice connection in TrackAudio is up. Pressing the action will force a state
 
 The ATIS letter action shows the current AITS letter for a station, refreshed automatically every minute.
 When the ATIS letter updates the action will show an orange background until the action is pressed to reset the
-state. Pressing the action when it is not in the updated state will force a refresh of the ATIS information.
+state. A long press of the action will force a refresh of the ATIS information.
 
 See the [SVG template documentation](https://github.com/neilenns/streamdeck-trackaudio/wiki/SVG-templates) for an example
 template that shows the title small and station letter big.

--- a/src/actions/atisLetter.ts
+++ b/src/actions/atisLetter.ts
@@ -46,9 +46,9 @@ export class AtisLetter extends SingletonAction<AtisLetterSettings> {
     const pressLength = Date.now() - this._keyDownStart;
 
     if (pressLength > LONG_PRESS_THRESHOLD) {
-      actionManager.atisLetterLongPress(ev.action.id);
+      actionManager.atisLetterLongPress(ev.action);
     } else {
-      actionManager.atisLetterShortPress(ev.action.id);
+      actionManager.atisLetterShortPress(ev.action);
     }
   }
 }

--- a/src/actions/atisLetter.ts
+++ b/src/actions/atisLetter.ts
@@ -1,18 +1,21 @@
 import {
   action,
   DidReceiveSettingsEvent,
-  KeyDownEvent,
+  KeyUpEvent,
   SingletonAction,
   WillAppearEvent,
   WillDisappearEvent,
 } from "@elgato/streamdeck";
 import actionManager from "@managers/action";
+import { LONG_PRESS_THRESHOLD } from "@utils/constants";
 
 @action({ UUID: "com.neil-enns.trackaudio.atisletter" })
 /**
  * Represents the status of a TrackAudio station
  */
 export class AtisLetter extends SingletonAction<AtisLetterSettings> {
+  private _keyDownStart = 0;
+
   // When the action is added to a profile it gets saved in the ActionManager
   // instance for use elsewhere in the code. The default title is also set
   // to something useful.
@@ -35,8 +38,18 @@ export class AtisLetter extends SingletonAction<AtisLetterSettings> {
     actionManager.updateAtisLetter(ev.action, ev.payload.settings);
   }
 
-  onKeyDown(ev: KeyDownEvent<AtisLetterSettings>): Promise<void> | void {
-    actionManager.atisLetterKeyDown(ev.action);
+  onKeyDown(): Promise<void> | void {
+    this._keyDownStart = Date.now();
+  }
+
+  onKeyUp(ev: KeyUpEvent<AtisLetterSettings>): Promise<void> | void {
+    const pressLength = Date.now() - this._keyDownStart;
+
+    if (pressLength > LONG_PRESS_THRESHOLD) {
+      actionManager.atisLetterLongPress(ev.action.id);
+    } else {
+      actionManager.atisLetterShortPress(ev.action.id);
+    }
   }
 }
 

--- a/src/actions/stationStatus.ts
+++ b/src/actions/stationStatus.ts
@@ -47,9 +47,9 @@ export class StationStatus extends SingletonAction<StationSettings> {
     const pressLength = Date.now() - this._keyDownStart;
 
     if (pressLength > LONG_PRESS_THRESHOLD) {
-      actionManager.stationStatusLongPress(ev.action.id);
+      actionManager.stationStatusLongPress(ev.action);
     } else {
-      actionManager.stationStatusShortPress(ev.action.id);
+      actionManager.stationStatusShortPress(ev.action);
     }
   }
 }

--- a/src/managers/action.ts
+++ b/src/managers/action.ts
@@ -134,31 +134,6 @@ class ActionManager extends EventEmitter {
   }
 
   /**
-   * Called when a station status action has a long press. Resets the
-   * station status and refreshses its state.
-   * @param actionId The ID of the action that had the long press
-   */
-  public stationStatusLongPress(actionId: string) {
-    const savedAction = this.getStationStatusControllers().find(
-      (entry) => entry.action.id === actionId
-    );
-
-    if (!savedAction) {
-      return;
-    }
-
-    savedAction.reset();
-    trackAudioManager.refreshStationState(savedAction.callsign);
-
-    savedAction.action.showOk().catch((error: unknown) => {
-      handleAsyncException(
-        "Unable to show OK on station status button:",
-        error
-      );
-    });
-  }
-
-  /**
    * Called when a TrackAudio status action keydown event is triggered.
    * Forces a refresh of the TrackAudio status.
    * @param action The action
@@ -179,9 +154,9 @@ class ActionManager extends EventEmitter {
    * Called when an ATIS letter action has a short press. Clears the state.
    * @param actionId The ID of the action that had the short press
    */
-  public atisLetterShortPress(actionId: string) {
+  public atisLetterShortPress(action: Action) {
     const savedAction = this.getAtisLetterControllers().find(
-      (entry) => entry.action.id === actionId
+      (entry) => entry.action.id === action.id
     );
 
     if (!savedAction) {
@@ -195,9 +170,9 @@ class ActionManager extends EventEmitter {
    * Called when an ATIS letter action has a long press. Refreshses the ATIS.
    * @param actionId The ID of the action that had the long press
    */
-  public atisLetterLongPress(actionId: string) {
+  public atisLetterLongPress(action: Action) {
     const savedAction = this.getAtisLetterControllers().find(
-      (entry) => entry.action.id === actionId
+      (entry) => entry.action.id === action.id
     );
 
     if (!savedAction) {
@@ -207,7 +182,7 @@ class ActionManager extends EventEmitter {
     savedAction.reset();
     vatsimManager.refresh();
 
-    savedAction.action.showOk().catch((error: unknown) => {
+    action.showOk().catch((error: unknown) => {
       handleAsyncException("Unable to show OK on ATIS button:", error);
     });
   }
@@ -578,13 +553,15 @@ class ActionManager extends EventEmitter {
   }
 
   /**
-   * Toggles the tx on both the primary and hotline frequency.
-   * @param id The action id to toggle the state of
+   * Handles the short press of a hotline action. Toggles the tx on both the primary and hotline frequency.
+   * @param actionId The action id to toggle the state of
    */
-  public toggleHotline(id: string): void {
-    const foundAction = this.actions.find((entry) => entry.action.id === id);
+  public hotlineShortPress(action: Action): void {
+    const foundAction = this.getHotlineControllers().find(
+      (entry) => entry.action.id === action.id
+    );
 
-    if (!foundAction || !isHotlineController(foundAction)) {
+    if (!foundAction) {
       return;
     }
 
@@ -623,14 +600,35 @@ class ActionManager extends EventEmitter {
     });
   }
 
+  public hotlineLongPress(action: Action) {
+    const foundAction = this.getHotlineControllers().find(
+      (entry) => entry.action.id === action.id
+    );
+
+    if (!foundAction) {
+      return;
+    }
+
+    foundAction.reset();
+    trackAudioManager.refreshStationState(foundAction.primaryCallsign);
+    trackAudioManager.refreshStationState(foundAction.hotlineCallsign);
+
+    action.showOk().catch((error: unknown) => {
+      handleAsyncException(
+        "Unable to show OK status on TrackAudio action: ",
+        error
+      );
+    });
+  }
+
   /**
    * Handles a short press of a station status action. Toggles the
    * the tx, rx, xc, or spkr state of a frequency bound to a StreamDeck action.
    * @param actionId The action id to toggle the state of
    */
-  public stationStatusShortPress(actionId: string): void {
+  public stationStatusShortPress(action: Action): void {
     const foundAction = this.actions.find(
-      (entry) => entry.action.id === actionId
+      (entry) => entry.action.id === action.id
     );
 
     if (!foundAction || !isStationStatusController(foundAction)) {
@@ -652,6 +650,31 @@ class ActionManager extends EventEmitter {
         xc: foundAction.listenTo === "xc" ? "toggle" : undefined,
         xca: foundAction.listenTo === "xca" ? "toggle" : undefined,
       },
+    });
+  }
+
+  /**
+   * Called when a station status action has a long press. Resets the
+   * station status and refreshses its state.
+   * @param actionId The ID of the action that had the long press
+   */
+  public stationStatusLongPress(action: Action) {
+    const savedAction = this.getStationStatusControllers().find(
+      (entry) => entry.action.id === action.id
+    );
+
+    if (!savedAction) {
+      return;
+    }
+
+    savedAction.reset();
+    trackAudioManager.refreshStationState(savedAction.callsign);
+
+    action.showOk().catch((error: unknown) => {
+      handleAsyncException(
+        "Unable to show OK on station status button:",
+        error
+      );
     });
   }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * The length of time in ms that has to pass for an action press to
+ * count as a long press.
+ */
+export const LONG_PRESS_THRESHOLD = 500;


### PR DESCRIPTION
Fixes #250 

* Long press on a station status, hotline, or ATIS action refreshes that action
* Long press on a TrackAudio status action refreshes all actions on the profile