### PR TITLE
Adjust default step to 2

### DIFF
--- a/com.neil-enns.trackaudio.sdPlugin/pi/mainVolume.html
+++ b/com.neil-enns.trackaudio.sdPlugin/pi/mainVolume.html
@@ -10,7 +10,7 @@
         setting="changeAmount"
         min="1"
         max="10"
-        default="1"
+        default="2"
         showlabels
         required
       ></sdpi-range>

--- a/com.neil-enns.trackaudio.sdPlugin/pi/stationVolume.html
+++ b/com.neil-enns.trackaudio.sdPlugin/pi/stationVolume.html
@@ -18,7 +18,7 @@
         setting="changeAmount"
         min="1"
         max="10"
-        default="1"
+        default="2"
         showlabels
         required
       ></sdpi-range>

--- a/src/controllers/mainVolume.ts
+++ b/src/controllers/mainVolume.ts
@@ -137,8 +137,8 @@ export class MainVolumeController extends BaseController {
    * Convenience property to get the changeAmount value of settings.
    */
   get changeAmount() {
-    const amount = this.settings.changeAmount ?? 1;
-    return amount > 0 ? amount : 1;
+    const amount = this.settings.changeAmount ?? 2;
+    return amount > 0 ? amount : 2;
   }
 
   override reset(): void {

--- a/src/controllers/stationVolume.ts
+++ b/src/controllers/stationVolume.ts
@@ -102,9 +102,9 @@ export class StationVolumeController extends BaseController {
 
     this._outputVolume = newValue;
 
-		// This isn't debounced to ensure speedy updates when the volume changes.
+    // This isn't debounced to ensure speedy updates when the volume changes.
     this.refreshImage();
-		this.refreshTitle();
+    this.refreshTitle();
   }
 
   /**
@@ -205,7 +205,8 @@ export class StationVolumeController extends BaseController {
    * Convenience property to get the changeAmount value of settings.
    */
   get changeAmount() {
-    return this.settings.changeAmount ?? 1;
+    const amount = this.settings.changeAmount ?? 2;
+    return amount > 0 ? amount : 2;
   }
 
   override reset(): void {


### PR DESCRIPTION
Fixes #372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Adjusted default volume change amount from 1 to 2 across main and station volume controls

- **Bug Fixes**
  - Ensured volume change amount is always at least 2 when not explicitly set
  - Improved volume control default settings for more consistent user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->