### PR TITLE
Force refresh of station dials when callsign changes

### DIFF
--- a/src/events/streamDeck/stationVolume/updateStationVolumeSettings.ts
+++ b/src/events/streamDeck/stationVolume/updateStationVolumeSettings.ts
@@ -1,6 +1,7 @@
 import { StationVolumeSettings } from "@actions/stationVolume";
 import { DialAction } from "@elgato/streamdeck";
 import actionManager from "@managers/action";
+import trackAudioManager from "@managers/trackAudio";
 
 /**
  * Updates the settings associated with a station volume action.
@@ -19,5 +20,11 @@ export const handleUpdateStationVolumeSettings = (
     return;
   }
 
+  const refreshRequired = savedAction.callsign !== settings.callsign;
+
   savedAction.settings = settings;
+
+  if (refreshRequired) {
+    trackAudioManager.refreshStationState(savedAction.callsign);
+  }
 };


### PR DESCRIPTION
Fixes #377

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced station volume settings management with conditional audio state refresh
	- Improved audio state synchronization when station callsign changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->