### PR TITLE
Don't show warning icon when adding an action and TrackAudio isn't running

### DIFF
--- a/src/controllers/hotline.ts
+++ b/src/controllers/hotline.ts
@@ -6,6 +6,7 @@ import { stringOrUndefined } from "@root/utils/utils";
 import { BaseController } from "./baseController";
 import debounce from "debounce";
 import { HOTLINE_CONTROLLER_TYPE } from "@utils/controllerTypes";
+import trackAudioManager from "@managers/trackAudio";
 
 const defaultTemplatePath = "images/actions/hotline/template.svg";
 
@@ -394,7 +395,7 @@ export class HotlineController extends BaseController {
       title: this.title,
     };
 
-    if (this.isAvailable !== undefined && !this.isAvailable) {
+    if (trackAudioManager.isVoiceConnected && !this.isAvailable) {
       this.setImage(this.unavailableImagePath, {
         ...replacements,
         state: "unavailable",

--- a/src/controllers/stationStatus.ts
+++ b/src/controllers/stationStatus.ts
@@ -8,6 +8,7 @@ import mainLogger from "@utils/logger";
 import debounce from "debounce";
 import { LRUCache } from "lru-cache";
 import { BaseController } from "./baseController";
+import trackAudioManager from "@managers/trackAudio";
 
 // Valid values for the ListenTo property. This must match
 // the list of array property names that come from TrackAudio
@@ -568,7 +569,7 @@ export class StationStatusController extends BaseController {
       outputVolume: this.outputVolume,
     };
 
-    if (this.isAvailable !== undefined && !this.isAvailable) {
+    if (trackAudioManager.isVoiceConnected && !this.isAvailable) {
       this.setImage(this.unavailableImagePath, {
         ...replacements,
         state: "unavailable",


### PR DESCRIPTION
Fixes #382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated station and hotline image display logic to consider voice connection status
- **Refactor**
	- Integrated `trackAudioManager` into station and hotline controllers to enhance connection state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->