### PR TITLE
Show station volume in red when muted

### DIFF
--- a/com.neil-enns.trackaudio.sdPlugin/images/actions/stationVolume/template.svg
+++ b/com.neil-enns.trackaudio.sdPlugin/images/actions/stationVolume/template.svg
@@ -7,6 +7,8 @@
 	        fill: grey;
 		{{else if (eq state "notConnected")}}
 	        fill: grey;
+		{{else if (eq state "muted")}}
+					fill: #a71d2a;
 		{{else}}
         	fill: #FFFFFF;
 		{{/if}}

--- a/src/controllers/stationVolume.ts
+++ b/src/controllers/stationVolume.ts
@@ -285,15 +285,15 @@ export class StationVolumeController extends BaseController {
     this.action
       .setFeedback({
         title: {
-          color: this.isOutputMuted ? "grey" : "#FFFFFF",
+          color: this.isOutputMuted ? "#a71d2a" : "#FFFFFF",
         },
         indicator: {
           value: this.outputVolume,
-          bar_fill_c: this.isOutputMuted ? "grey" : "#FFFFFF",
+          bar_fill_c: this.isOutputMuted ? "#a71d2a" : "#FFFFFF",
         },
         value: {
           value: `${this.outputVolume.toString()}%`,
-          color: this.isOutputMuted ? "grey" : "#FFFFFF",
+          color: this.isOutputMuted ? "#a71d2a" : "#FFFFFF",
         },
       })
       .catch((error: unknown) => {


### PR DESCRIPTION
Fixes #385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated color scheme for muted station volume display
	- Changed muted state indicator from grey to a distinct red color (#a71d2a)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->