### PR TITLE
Clean up code comments on controllers

### DIFF
--- a/src/actions/stationStatus.ts
+++ b/src/actions/stationStatus.ts
@@ -9,8 +9,8 @@ import {
   WillAppearEvent,
   WillDisappearEvent,
 } from "@elgato/streamdeck";
-import { handleAddStation } from "@events/streamDeck/stationStatus/addStation";
 import { handleRemove } from "@events/streamDeck/remove";
+import { handleAddStation } from "@events/streamDeck/stationStatus/addStation";
 import { handleStationStatusLongPress } from "@events/streamDeck/stationStatus/stationStatusLongPress";
 import { handleStationStatusShortPress } from "@events/streamDeck/stationStatus/stationStatusShortPress";
 import { handleUpdateStation } from "@events/streamDeck/stationStatus/updateStation";
@@ -21,18 +21,21 @@ import debounce from "debounce";
 /**
  * Represents the status of a TrackAudio station
  */
-export class StationStatus extends SingletonAction<StationSettings> {
+export class StationStatus extends SingletonAction<StationStatusSettings> {
   private _keyDownStart = 0;
 
-  debouncedUpdate = debounce((action: KeyAction, settings: StationSettings) => {
-    handleUpdateStation(action, settings);
-  }, 300);
+  debouncedUpdate = debounce(
+    (action: KeyAction, settings: StationStatusSettings) => {
+      handleUpdateStation(action, settings);
+    },
+    300
+  );
 
   // When the action is added to a profile it gets saved in the ActionManager
   // instance for use elsewhere in the code. The default title is also set
   // to something useful.
   override onWillAppear(
-    ev: WillAppearEvent<StationSettings>
+    ev: WillAppearEvent<StationStatusSettings>
   ): void | Promise<void> {
     // This should never happen. Typeguard to ensure the rest of the code can just use
     // KeyAction.
@@ -45,7 +48,7 @@ export class StationStatus extends SingletonAction<StationSettings> {
 
   // When the action is removed from a profile it also gets removed from the ActionManager.
   override onWillDisappear(
-    ev: WillDisappearEvent<StationSettings>
+    ev: WillDisappearEvent<StationStatusSettings>
   ): void | Promise<void> {
     handleRemove(ev.action);
   }
@@ -53,7 +56,7 @@ export class StationStatus extends SingletonAction<StationSettings> {
   // When settings are received the ActionManager is called to update the existing
   // settings on the saved action.
   override onDidReceiveSettings(
-    ev: DidReceiveSettingsEvent<StationSettings>
+    ev: DidReceiveSettingsEvent<StationStatusSettings>
   ): void | Promise<void> {
     // This should never happen. Typeguard to ensure the rest of the code can just use
     // KeyAction.
@@ -68,7 +71,9 @@ export class StationStatus extends SingletonAction<StationSettings> {
     this._keyDownStart = Date.now();
   }
 
-  override onKeyUp(ev: KeyUpEvent<StationSettings>): Promise<void> | void {
+  override onKeyUp(
+    ev: KeyUpEvent<StationStatusSettings>
+  ): Promise<void> | void {
     const pressLength = Date.now() - this._keyDownStart;
 
     if (pressLength > LONG_PRESS_THRESHOLD) {
@@ -79,8 +84,9 @@ export class StationStatus extends SingletonAction<StationSettings> {
   }
 }
 
-export interface StationSettings {
+export interface StationStatusSettings {
   autoSetListen?: boolean;
+  autoSetSpk?: boolean;
   autoSetRx?: boolean;
   blockedCommsImagePath?: string;
   activeCommsImagePath?: string;

--- a/src/controllers/atisLetter.ts
+++ b/src/controllers/atisLetter.ts
@@ -243,7 +243,7 @@ export class AtisLetterController extends BaseController {
   //#endregion
 
   /**
-   * Sets the image based on the state of the action.
+   * Sets the displayed image based on the state of the action.
    */
   private refreshImage() {
     const replacements = {
@@ -275,7 +275,7 @@ export class AtisLetterController extends BaseController {
   }
 
   /**
-   * Sets the title on the action.
+   * Sets the displayed title based on the state of the action.
    */
   private refreshTitle() {
     const title = new TitleBuilder();

--- a/src/controllers/atisLetter.ts
+++ b/src/controllers/atisLetter.ts
@@ -102,7 +102,7 @@ export class AtisLetterController extends BaseController {
   }
 
   /**
-   * Sets the currentImagePath and re-compiles the SVG template if necessary.
+   * Sets the currentImagePath.
    */
   set currentImagePath(newValue: string | undefined) {
     this._currentImagePath = stringOrUndefined(newValue);
@@ -117,7 +117,7 @@ export class AtisLetterController extends BaseController {
   }
 
   /**
-   * Sets the updatedImagePath and re-compiles the SVG template if necessary.
+   * Sets the updatedImagePath.
    */
   set updatedImagePath(newValue: string | undefined) {
     this._updatedImagePath = stringOrUndefined(newValue);
@@ -132,7 +132,7 @@ export class AtisLetterController extends BaseController {
   }
 
   /**
-   * Sets the unavailableImagePath and re-compiles the SVG template if necessary.
+   * Sets the unavailableImagePath.
    */
   set unavailableImagePath(newValue: string | undefined) {
     this._unavailableImagePath = stringOrUndefined(newValue);

--- a/src/controllers/atisLetter.ts
+++ b/src/controllers/atisLetter.ts
@@ -86,8 +86,8 @@ export class AtisLetterController extends BaseController {
   }
 
   /**
-   * Gets the callsign for the ATIS action.
-   * @returns {string} The callsign, or undefined if no callsign is set.
+   * Gets the callsign value from settings.
+   * @returns {string | undefined} The callsign. Defaults to undefined.
    */
   get callsign(): string | undefined {
     return this.settings.callsign;
@@ -234,8 +234,8 @@ export class AtisLetterController extends BaseController {
   }
 
   /**
-   * Gets the action's title from settings.
-   * @returns { string | undefined } The title, or undefined if none is set.
+   * Gets the title value from settings.
+   * @returns { string | undefined } The title. Defaults to undefined.
    */
   get title(): string | undefined {
     return this.settings.title;

--- a/src/controllers/atisLetter.ts
+++ b/src/controllers/atisLetter.ts
@@ -3,9 +3,9 @@ import { KeyAction } from "@elgato/streamdeck";
 import { Controller } from "@interfaces/controller";
 import TitleBuilder from "@root/utils/titleBuilder";
 import { stringOrUndefined } from "@root/utils/utils";
-import { BaseController } from "./baseController";
-import debounce from "debounce";
 import { ATIS_LETTER_CONTROLLER_TYPE } from "@utils/controllerTypes";
+import debounce from "debounce";
+import { BaseController } from "./baseController";
 
 const defaultTemplatePath = "images/actions/atisLetter/template.svg";
 
@@ -57,16 +57,18 @@ export class AtisLetterController extends BaseController {
 
   //#region Getters and setters
   /**
-   * Gets the autoClear setting, returning true as default if it wasn't set.
+   * Gets the autoClear setting.
+   * @returns {boolean} True if auto clear is enabled. Defaults to true.
    */
-  get autoClear() {
+  get autoClear(): boolean {
     return this.settings.autoClear ?? true;
   }
 
   /**
-   * Gets isUnavailable, which is true if no ATIS letter was available in the last VATSIM update.
+   * Gets isUnavailable.
+   * @returns {boolean} True if no ATIS letter is available for the station.
    */
-  get isUnavailable() {
+  get isUnavailable(): boolean {
     return this._isUnavailable;
   }
 
@@ -84,15 +86,16 @@ export class AtisLetterController extends BaseController {
   }
 
   /**
-   * Returns the callsign for the ATIS action.
+   * Gets the callsign for the ATIS action.
+   * @returns {string} The callsign, or undefined if no callsign is set.
    */
-  get callsign() {
+  get callsign(): string | undefined {
     return this.settings.callsign;
   }
 
   /**
-   * Returns the currentImagePath or the default template path if the
-   * user didn't specify a custom icon.
+   * Gets the path to the current image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get currentImagePath(): string {
     return this._currentImagePath ?? defaultTemplatePath;
@@ -106,8 +109,8 @@ export class AtisLetterController extends BaseController {
   }
 
   /**
-   * Returns the updatedImagePath or the default template path if the user
-   * didn't specify a custom icon.
+   * Gets the path to the updated image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get updatedImagePath(): string {
     return this._updatedImagePath ?? defaultTemplatePath;
@@ -121,8 +124,8 @@ export class AtisLetterController extends BaseController {
   }
 
   /**
-   * Returns the unavailableImagePath or the default unavailable template path
-   * if the user didn't specify a custom icon.
+   * Gets the path to the unavailable image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get unavailableImagePath(): string {
     return this._unavailableImagePath ?? defaultTemplatePath;
@@ -136,23 +139,26 @@ export class AtisLetterController extends BaseController {
   }
 
   /**
-   * Returns the showTitle setting, or true if undefined.
+   * Gets the showTitle setting.
+   * @returns {boolean} True if showTitle is enabled. Defaults to true.
    */
-  get showTitle() {
+  get showTitle(): boolean {
     return this.settings.showTitle ?? true;
   }
 
   /**
-   * Returns the showLetter setting, or true if undefined.
+   * Gets the showLetter setting.
+   * @returns {boolean} True if showLetter is enabled. Defaults to true.
    */
-  get showLetter() {
+  get showLetter(): boolean {
     return this.settings.showLetter ?? true;
   }
 
   /**
    * Gets the settings.
+   * @returns {AtisLetterSettings} The settings.
    */
-  get settings() {
+  get settings(): AtisLetterSettings {
     if (this._settings === null) {
       throw new Error("Settings not initialized. This should never happen.");
     }
@@ -161,8 +167,7 @@ export class AtisLetterController extends BaseController {
   }
 
   /**
-   * Sets the settings. Also updates the private icon paths and
-   * compiled SVGs.
+   * Sets the settings. Also updates the private icon paths.
    */
   set settings(newValue: AtisLetterSettings) {
     this._settings = newValue;
@@ -176,8 +181,9 @@ export class AtisLetterController extends BaseController {
 
   /**
    * Gets the isUpdated state on the action.
+   * @returns {boolean} True if the ATIS is updated.
    */
-  public get isUpdated() {
+  public get isUpdated(): boolean {
     return this._isUpdated;
   }
 
@@ -204,13 +210,14 @@ export class AtisLetterController extends BaseController {
 
   /**
    * Gets the current ATIS letter.
+   * @returns {string | undefined} The current ATIS letter, or undefined if no letter is set.
    */
   get letter(): string | undefined {
     return this._letter;
   }
 
   /**
-   * Sets the current AITS letter.
+   * Sets the current ATIS letter and updates the display.
    */
   set letter(newLetter: string | undefined) {
     // This crazy check catches two situations where the state should not show as updated:
@@ -227,9 +234,10 @@ export class AtisLetterController extends BaseController {
   }
 
   /**
-   * Convenience method to return the action's title from settings.
+   * Gets the action's title from settings.
+   * @returns { string | undefined } The title, or undefined if none is set.
    */
-  get title() {
+  get title(): string | undefined {
     return this.settings.title;
   }
   //#endregion

--- a/src/controllers/atisLetter.ts
+++ b/src/controllers/atisLetter.ts
@@ -45,7 +45,7 @@ export class AtisLetterController extends BaseController {
   });
 
   /**
-   * Resets the action to its default, disconnected, state.
+   * Resets the action to its default state.
    */
   public reset() {
     this._letter = undefined;

--- a/src/controllers/atisLetter.ts
+++ b/src/controllers/atisLetter.ts
@@ -38,6 +38,7 @@ export class AtisLetterController extends BaseController {
 
   /**
    * Refreshes the title and image on the action.
+   * @remarks This method is debounced with a 100ms delay to prevent excessive updates.
    */
   public override refreshDisplay = debounce(() => {
     this.refreshTitle();

--- a/src/controllers/baseController.ts
+++ b/src/controllers/baseController.ts
@@ -20,7 +20,7 @@ export abstract class BaseController implements Controller {
 
   /**
    * Initializes the BaseController.
-   * @param action The Stream Deck icon this wraps
+   * @param action The Stream Deck action this wraps
    */
   constructor(action: KeyAction | DialAction) {
     this.action = action;
@@ -48,11 +48,11 @@ export abstract class BaseController implements Controller {
   }
 
   /**
-   * Sets the image on the tracked action. If the image is a stored
+   * Sets the image on a key action. If the image is a stored
    * SVG template then the template is populated and used. Otherwise
    * the path is used directly.
-   * @param imagePath The path to the image
-   * @param replacements The replacements to use
+   * @param imagePath The path to the image.
+   * @param replacements The replacements to use.
    */
   setImage(imagePath: string, replacements: object) {
     const generatedSvg = svgManager.renderSvg(imagePath, replacements);
@@ -67,6 +67,13 @@ export abstract class BaseController implements Controller {
     }
   }
 
+  /**
+   * Sets the feedback image on a dial action. If the image is a stored
+   * SVG template then the template is populated and used. Otherwise
+   * the path is used directly.
+   * @param imagePath The path to the image.
+   * @param replacements The replacements to use.
+   */
   setFeedbackImage(imagePath: string, replacements: object) {
     if (!this.action.isDial()) {
       return;

--- a/src/controllers/hotline.ts
+++ b/src/controllers/hotline.ts
@@ -53,7 +53,7 @@ export class HotlineController extends BaseController {
   }, 100);
 
   /**
-   * Resets the action to its default, disconnected, state.
+   * Resets the action to its default state.
    */
   public reset() {
     this._isReceiving = false;

--- a/src/controllers/hotline.ts
+++ b/src/controllers/hotline.ts
@@ -384,7 +384,7 @@ export class HotlineController extends BaseController {
   //#endregion
 
   /**
-   * Sets the title on the action.
+   * Sets the displayed title based on the state of the action.
    */
   private refreshTitle() {
     const title = new TitleBuilder();
@@ -398,7 +398,7 @@ export class HotlineController extends BaseController {
   }
 
   /**
-   * Sets the image based on the state of the action.
+   * Sets the displayed image based on the state of the action.
    */
   private refreshImage() {
     const replacements = {

--- a/src/controllers/hotline.ts
+++ b/src/controllers/hotline.ts
@@ -1,12 +1,12 @@
 import { HotlineSettings } from "@actions/hotline";
 import { KeyAction } from "@elgato/streamdeck";
 import { Controller } from "@interfaces/controller";
+import trackAudioManager from "@managers/trackAudio";
 import TitleBuilder from "@root/utils/titleBuilder";
 import { stringOrUndefined } from "@root/utils/utils";
-import { BaseController } from "./baseController";
-import debounce from "debounce";
 import { HOTLINE_CONTROLLER_TYPE } from "@utils/controllerTypes";
-import trackAudioManager from "@managers/trackAudio";
+import debounce from "debounce";
+import { BaseController } from "./baseController";
 
 const defaultTemplatePath = "images/actions/hotline/template.svg";
 
@@ -70,113 +70,114 @@ export class HotlineController extends BaseController {
 
   //#region Getters/setters
   /**
-   * Convenience method to return the action's title from settings or empty string
-   * if it is undefined.
+   * Gets the action's title from settings.
+   * @returns { string | undefined } The title, or undefined if none is set.
    */
-  get title() {
+  get title(): string | undefined {
     return this.settings.title ?? "";
   }
 
   /**
-   * Returns the bothActiveImagePath or the default template path if the
-   * user didn't specify a custom icon.
+   * Gets the path to the both active image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get bothActiveImagePath(): string {
     return this._bothActiveImagePath ?? defaultTemplatePath;
   }
 
   /**
-   * Sets the bothActiveImagePath and re-compiles the SVG template if necessary.
+   * Sets the bothActiveImagePath.
    */
   set bothActiveImagePath(newValue: string | undefined) {
     this._bothActiveImagePath = stringOrUndefined(newValue);
   }
 
   /**
-   * Returns the unavailableImagePath or the default template path if the
-   * user didn't specify a custom icon.
+   * Gets the path to the unavailable image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get unavailableImagePath(): string {
     return this._unavailableImagePath ?? defaultTemplatePath;
   }
 
   /**
-   * Sets the unavailableImagePath and re-compiles the SVG template if necessary.
+   * Sets the unavailableImagePath.
    */
   set unavailableImagePath(newValue: string | undefined) {
     this._unavailableImagePath = stringOrUndefined(newValue);
   }
 
   /**
-   * Returns the hotlineActiveImagePath or the default template path if the
-   * user didn't specify a custom icon.
+   * Gets the path to the hotline active image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get hotlineActiveImagePath(): string {
     return this._hotlineActiveImagePath ?? defaultTemplatePath;
   }
 
   /**
-   * Sets the hotlineActiveImagePath and re-compiles the SVG template if necessary.
+   * Sets the hotlineActiveImagePath.
    */
   set hotlineActiveImagePath(newValue: string | undefined) {
     this._hotlineActiveImagePath = stringOrUndefined(newValue);
   }
 
   /**
-   * Returns the listeningImagePath or the default template path if the
-   * user didn't specify a custom icon.
+   * Gets the path to the listening image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get listeningImagePath(): string {
     return this._listeningImagePath ?? defaultTemplatePath;
   }
 
   /**
-   * Sets the listeningImagePath and re-compiles the SVG template if necessary.
+   * Sets the listeningImagePath.
    */
   set listeningImagePath(newValue: string | undefined) {
     this._listeningImagePath = stringOrUndefined(newValue);
   }
 
   /**
-   * Returns the neitherActiveImagePath or the default template path if the
-   * user didn't specify a custom icon.
+   * Gets the path to the neither active image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get neitherActiveImagePath(): string {
     return this._neitherActiveImagePath ?? defaultTemplatePath;
   }
 
   /**
-   * Sets the neitherActiveImagePath and re-compiles the SVG template if necessary.
+   * Sets the neitherActiveImagePath.
    */
   set neitherActiveImagePath(newValue: string | undefined) {
     this._neitherActiveImagePath = stringOrUndefined(newValue);
   }
 
   /**
-   * Returns the receivingImagePath or the default template path if the
-   * user didn't specify a custom icon.
+   * Gets the path to the receiving image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get receivingImagePath(): string {
     return this._receivingImagePath ?? defaultTemplatePath;
   }
 
   /**
-   * Sets the receivingImagePath and re-compiles the SVG template if necessary.
+   * Sets the receivingImagePath.
    */
   set receivingImagePath(newValue: string | undefined) {
     this._receivingImagePath = stringOrUndefined(newValue);
   }
 
   /**
-   * Returns the frequency for the primary callsign.
+   * Gets the frequency for the primary callsign.
+   * @returns {number} The frequency or 0 if the frequency isn't set.
    */
-  get primaryFrequency() {
+  get primaryFrequency(): number {
     return this._primaryFrequency;
   }
 
   /**
    * Sets the frequency for the primary callsign and updates the isAvailable
-   * to true if both primary and hotline frequency are set
+   * to true if both primary and hotline frequency are set.
    */
   set primaryFrequency(newValue: number) {
     // This is always done even if the new value is the same as the existing one
@@ -190,8 +191,9 @@ export class HotlineController extends BaseController {
 
   /**
    * Gets the frequency for the hotline callsign.
+   * @returns {number} The frequency or 0 if the frequency isn't set.
    */
-  get hotlineFrequency() {
+  get hotlineFrequency(): number {
     return this._hotlineFrequency;
   }
 
@@ -210,14 +212,15 @@ export class HotlineController extends BaseController {
   }
 
   /**
-   * True if both the primary and hotline frequencies are available in TrackAudio.
+   * Gets the isAvailable value.
+   * @returns {boolean | undefined} True if both the primary and hotline frequencies are available in TrackAudio.
    */
   get isAvailable(): boolean | undefined {
     return this._isAvailable;
   }
 
   /**
-   * Sets the isAvailable property and updates the action image accordingly.
+   * Sets the isAvailable property and updates the action image.
    */
   set isAvailable(newValue: boolean | undefined) {
     if (this._isAvailable === newValue) {
@@ -229,7 +232,8 @@ export class HotlineController extends BaseController {
   }
 
   /**
-   * Sets whether the hotline frequency is actively receiving a communication.
+   * Sets whether the hotline frequency is actively receiving a communication
+   *  and updates the action image.
    */
   set isReceiving(newValue: boolean) {
     // Don't do anything if the state is the same
@@ -242,16 +246,18 @@ export class HotlineController extends BaseController {
   }
 
   /**
-   * True if the hotline frequency is actively receicving a communication.
+   * Gets the isReceiving property.
+   * @returns {boolean} True if the hotline frequency is actively receiving a communication.
    */
-  get isReceiving() {
+  get isReceiving(): boolean {
     return this._isReceiving;
   }
 
   /**
-   * True if the station has Tx enabled on the primary frequency.
+   * Gets the isTxPrimary property.
+   * @returns {boolean} True if the station has Tx enabled on the primary frequency.
    */
-  get isTxPrimary() {
+  get isTxPrimary(): boolean {
     return this._isTxPrimary;
   }
 
@@ -263,9 +269,10 @@ export class HotlineController extends BaseController {
   }
 
   /**
-   * True if the station has Tx enabled on the hotline frequency.
+   * Gets the isTxHotline property.
+   * @returns {boolean} True if the station has Tx enabled on the hotline frequency.
    */
-  get isTxHotline() {
+  get isTxHotline(): boolean {
     return this._isTxHotline;
   }
 
@@ -277,9 +284,10 @@ export class HotlineController extends BaseController {
   }
 
   /**
-   * True if the station has Rx enabled on the hotline frequency.
+   * Gets the isRxHotline property.
+   * @returns {boolean} True if the station has Rx enabled on the hotline frequency.
    */
-  get isRxHotline() {
+  get isRxHotline(): boolean {
     return this._isRxHotline;
   }
 
@@ -291,44 +299,50 @@ export class HotlineController extends BaseController {
   }
 
   /**
-   * Convenience property to get the primaryCallsign value of settings.
+   * Gets the primaryCallsign value from settings.
+   * @returns {string | undefined} The primary callsign, or undefined if not specified.
    */
-  get primaryCallsign() {
+  get primaryCallsign(): string | undefined {
     return this.settings.primaryCallsign;
   }
 
   /**
-   * Convenience property to get the hotlineCallsign value of settings.
+   * Gets the hotlineCallsign value from settings.
+   * @returns {string | undefined} The hotline callsign, or undefined if not specified.
    */
-  get hotlineCallsign() {
+  get hotlineCallsign(): string | undefined {
     return this.settings.hotlineCallsign;
   }
 
   /**
-   * Returns the showTitle setting, or true if undefined.
+   * Gets the showTitle setting.
+   * @returns {boolean} True if showTitle is enabled. Defaults to true.
    */
-  get showTitle() {
+  get showTitle(): boolean {
     return this.settings.showTitle ?? true;
   }
 
   /**
-   * Returns the showHotlineCallsign setting, or false if undefined.
+   * Gets the showHotlineCallsign setting.
+   * @returns {boolean} True if showHotlineCallsign is enabled. Defaults to true.
    */
-  get showHotlineCallsign() {
+  get showHotlineCallsign(): boolean {
     return this.settings.showHotlineCallsign ?? false;
   }
 
   /**
-   * Returns the showPrimaryCallsign setting, or false if undefined.
+   * Gets the showPrimaryCallsign setting.
+   * @returns {boolean} True if showPrimaryCallsign is enabled. Defaults to true.
    */
-  get showPrimaryCallsign() {
+  get showPrimaryCallsign(): boolean {
     return this.settings.showPrimaryCallsign ?? false;
   }
 
   /**
    * Gets the settings.
+   * @returns {HotlineSettings} The settings.
    */
-  get settings() {
+  get settings(): HotlineSettings {
     if (this._settings === null) {
       throw new Error("Settings not initialized. This should never happen.");
     }

--- a/src/controllers/hotline.ts
+++ b/src/controllers/hotline.ts
@@ -45,7 +45,8 @@ export class HotlineController extends BaseController {
   }
 
   /**
-   * Updates the title and image on the action.
+   * Refreshes the title and image on the action.
+   * @remarks This method is debounced with a 100ms delay to prevent excessive updates.
    */
   public override refreshDisplay = debounce(() => {
     this.refreshTitle();
@@ -71,10 +72,10 @@ export class HotlineController extends BaseController {
   //#region Getters/setters
   /**
    * Gets the action's title from settings.
-   * @returns { string | undefined } The title, or undefined if none is set.
+   * @returns { string | undefined } The title. Defaults to undefined.
    */
   get title(): string | undefined {
-    return this.settings.title ?? "";
+    return this.settings.title;
   }
 
   /**

--- a/src/controllers/mainVolume.ts
+++ b/src/controllers/mainVolume.ts
@@ -8,9 +8,7 @@ import { stringOrUndefined } from "@utils/utils";
 import debounce from "debounce";
 import { BaseController } from "./baseController";
 
-const defaultConnectedTemplatePath = "images/actions/mainVolume/template.svg";
-const defaultNotConnectedTemplatePath =
-  "images/actions/mainVolume/template.svg";
+const defaultTemplatePath = "images/actions/mainVolume/template.svg";
 
 export class MainVolumeController extends BaseController {
   type = MAIN_VOLUME_CONTROLLER_TYPE;
@@ -25,8 +23,8 @@ export class MainVolumeController extends BaseController {
 
   /**
    * Creates a new MainVolumeController object.
-   * @param action The dial action associated with the controller
-   * @param settings: The options for the action
+   * @param action The dial action associated with the controller.
+   * @param settings: The options for the action.
    */
   constructor(action: DialAction, settings: MainVolumeSettings) {
     super(action);
@@ -43,42 +41,45 @@ export class MainVolumeController extends BaseController {
   }, 100);
 
   /**
-   * Gets the connected SVG template path.
+   * Gets the path to the connected image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get connectedTemplatePath(): string {
-    return this._connectedTemplatePath ?? defaultConnectedTemplatePath;
+    return this._connectedTemplatePath ?? defaultTemplatePath;
   }
 
   /**
-   * Sets the connected SVG template path.
+   * Sets the connectedTemplatePath.
    */
   set connectedTemplatePath(newValue: string | undefined) {
     this._connectedTemplatePath = stringOrUndefined(newValue);
   }
 
   /**
-   * Gets the not connected SVG template path.
+   * Gets the path to the not connected image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get notConnectedTemplatePath(): string {
-    return this._notConnectedTemplatePath ?? defaultNotConnectedTemplatePath;
+    return this._notConnectedTemplatePath ?? defaultTemplatePath;
   }
 
   /**
-   * Sets the not connected SVG template path.
+   * Sets the notConnectedTemplatePath.
    */
   set notConnectedTemplatePath(newValue: string | undefined) {
     this._notConnectedTemplatePath = stringOrUndefined(newValue);
   }
 
   /**
-   * Gets the output volume. Returns 100 if undefined.
+   * Gets the output volume.
+   * @returns {number} The output volume. Defaults to 100.
    **/
   get volume(): number {
     return this._volume;
   }
 
   /**
-   * Sets the output volume.
+   * Sets the output volume and refreshes the action display.
    **/
   set volume(newValue: number) {
     if (this._volume === newValue) {
@@ -94,6 +95,7 @@ export class MainVolumeController extends BaseController {
 
   /**
    * Gets the settings.
+   * @returns {MainVolumeSettings} The settings.
    */
   get settings(): MainVolumeSettings {
     if (this._settings === null) {
@@ -115,19 +117,26 @@ export class MainVolumeController extends BaseController {
   }
 
   /**
-   * Convenience property to get the changeAmount value of settings.
+   * Gets the changeAmount.
+   * @returns {number} The amount to change the volume on each dial tick. Defaults to 2.
    */
-  get changeAmount() {
+  get changeAmount(): number {
     const amount = this.settings.changeAmount ?? 2;
     return amount > 0 ? amount : 2;
   }
 
+  /**
+   * Resets the action to defaults and refreshes the display.
+   */
   override reset(): void {
     this._volume = 100;
 
     this.refreshDisplay();
   }
 
+  /**
+   * Sets the displayed image based on the state of the action.
+   */
   private refreshImage(): void {
     const replacements = {
       volume: this.volume,
@@ -141,6 +150,9 @@ export class MainVolumeController extends BaseController {
     this.setFeedbackImage(templatePath, replacements);
   }
 
+  /**
+   * Sets the displayed title based on the state of the action.
+   */
   private refreshTitle(): void {
     if (!trackAudioManager.isVoiceConnected) {
       this.action

--- a/src/controllers/mainVolume.ts
+++ b/src/controllers/mainVolume.ts
@@ -41,6 +41,15 @@ export class MainVolumeController extends BaseController {
   }, 100);
 
   /**
+   * Resets the action to its default state.
+   */
+  override reset(): void {
+    this._volume = 100;
+
+    this.refreshDisplay();
+  }
+
+  /**
    * Gets the path to the connected image template.
    * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
@@ -123,15 +132,6 @@ export class MainVolumeController extends BaseController {
   get changeAmount(): number {
     const amount = this.settings.changeAmount ?? 2;
     return amount > 0 ? amount : 2;
-  }
-
-  /**
-   * Resets the action to defaults and refreshes the display.
-   */
-  override reset(): void {
-    this._volume = 100;
-
-    this.refreshDisplay();
   }
 
   /**

--- a/src/controllers/mainVolume.ts
+++ b/src/controllers/mainVolume.ts
@@ -34,6 +34,7 @@ export class MainVolumeController extends BaseController {
 
   /**
    * Refreshes the title and image on the action.
+   * @remarks This method is debounced with a 100ms delay to prevent excessive updates.
    */
   public override refreshDisplay = debounce(() => {
     this.refreshTitle();

--- a/src/controllers/pushToTalk.ts
+++ b/src/controllers/pushToTalk.ts
@@ -33,6 +33,7 @@ export class PushToTalkController extends BaseController {
 
   /**
    * Refreshes the title and image on the action.
+   * @remarks This method is debounced with a 100ms delay to prevent excessive updates.
    */
   public override refreshDisplay = debounce(() => {
     this.refreshTitle();

--- a/src/controllers/pushToTalk.ts
+++ b/src/controllers/pushToTalk.ts
@@ -3,9 +3,9 @@ import { KeyAction } from "@elgato/streamdeck";
 import { Controller } from "@interfaces/controller";
 import TitleBuilder from "@root/utils/titleBuilder";
 import { stringOrUndefined } from "@root/utils/utils";
-import { BaseController } from "./baseController";
-import debounce from "debounce";
 import { PUSH_TO_TALK_CONTROLLER_TYPE } from "@utils/controllerTypes";
+import debounce from "debounce";
+import { BaseController } from "./baseController";
 
 const defaultTemplatePath = "images/actions/pushToTalk/template.svg";
 
@@ -40,7 +40,7 @@ export class PushToTalkController extends BaseController {
   }, 100);
 
   /**
-   * Resets the action to its default, disconnected, state.
+   * Resets the action to its default state.
    */
   public reset() {
     this.isTransmitting = false;
@@ -48,53 +48,56 @@ export class PushToTalkController extends BaseController {
 
   //#region Getters and setters
   /**
-   * Returns the transmittingImagePath or the default template path if the
-   * user didn't specify a custom icon.
+   * Gets the path to the transmitting image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get transmittingImagePath(): string {
     return this._transmittingImagePath ?? defaultTemplatePath;
   }
 
   /**
-   * Sets the transmittingImagePath and re-compiles the SVG template if necessary.
+   * Sets the transmittingImagePath.
    */
   set transmittingImagePath(newValue: string | undefined) {
     this._transmittingImagePath = stringOrUndefined(newValue);
   }
 
   /**
-   * Returns the notTransmittingImagePath or the default template path if the
-   * user didn't specify a custom icon.
+   * Gets the path to the not transmitting image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get notTransmittingImagePath(): string {
     return this._notTransmittingImagePath ?? defaultTemplatePath;
   }
 
   /**
-   * Sets the notTransmittingImagePath and re-compiles the SVG template if necessary.
+   * Sets the notTransmittingImagePath.
    */
   set notTransmittingImagePath(newValue: string | undefined) {
     this._notTransmittingImagePath = stringOrUndefined(newValue);
   }
 
   /**
-   * Convenience method to return the action's title from settings.
+   * Gets the action's title from settings.
+   * @returns { string | undefined } The title, or undefined if none is set.
    */
-  get title() {
+  get title(): string | undefined {
     return this.settings.title;
   }
 
   /**
-   * Returns the showTitle setting, or false if undefined.
+   * Gets the showTitle setting.
+   * @returns {boolean} True if showTitle is enabled. Defaults to true.
    */
-  get showTitle() {
+  get showTitle(): boolean {
     return this.settings.showTitle ?? false;
   }
 
   /**
-   * True if push-to-talk is actively transmitting.
+   * Gets the isTransmitting property.
+   * @returns {boolean} True if transmitting is active.
    */
-  get isTransmitting() {
+  get isTransmitting(): boolean {
     return this._isTransmitting;
   }
 
@@ -113,8 +116,9 @@ export class PushToTalkController extends BaseController {
 
   /**
    * Gets the settings.
+   * @returns {PushToTalkSettings} The settings.
    */
-  get settings() {
+  get settings(): PushToTalkSettings {
     if (this._settings === null) {
       throw new Error("Settings not initialized. This should never happen.");
     }
@@ -136,7 +140,7 @@ export class PushToTalkController extends BaseController {
   //#endregion
 
   /**
-   * Sets the title on the action.
+   * Sets the displayed title based on the state of the action.
    */
   private refreshTitle() {
     const title = new TitleBuilder();
@@ -147,7 +151,7 @@ export class PushToTalkController extends BaseController {
   }
 
   /**
-   * Sets the action image to the correct one for when comms are active.
+   * Sets the displayed image based on the state of the action.
    */
   private refreshImage() {
     const replacements = {

--- a/src/controllers/stationStatus.ts
+++ b/src/controllers/stationStatus.ts
@@ -61,6 +61,7 @@ export class StationStatusController extends BaseController {
 
   /**
    * Refreshes the title and image on the action.
+   * @remarks This method is debounced with a 100ms delay to prevent excessive updates.
    */
   public override refreshDisplay = debounce(() => {
     logger.debug(`Refreshing display for ${this.callsign ?? ""}`);

--- a/src/controllers/stationStatus.ts
+++ b/src/controllers/stationStatus.ts
@@ -538,8 +538,7 @@ export class StationStatusController extends BaseController {
   }
 
   /**
-   * Resets the action to the initial display state: no last received callsign
-   * and no active coms image.
+   * Resets the action to its default state.
    */
   public reset() {
     this._lastReceivedCallsign = undefined; // This also clears _lastReceivedCallsignHistory

--- a/src/controllers/stationVolume.ts
+++ b/src/controllers/stationVolume.ts
@@ -45,6 +45,18 @@ export class StationVolumeController extends BaseController {
   }, 100);
 
   /**
+   * Resets the action to its default state.
+   */
+  override reset(): void {
+    this._isAvailable = undefined;
+    this._isOutputMuted = false;
+    this._frequency = 0;
+    this._outputVolume = 100;
+
+    this.refreshDisplay();
+  }
+
+  /**
    * Gets the path to the not muted image template.
    * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
@@ -218,18 +230,6 @@ export class StationVolumeController extends BaseController {
   get changeAmount(): number {
     const amount = this.settings.changeAmount ?? 2;
     return amount > 0 ? amount : 2;
-  }
-
-  /**
-   * Resets the action to defaults and refreshes the display.
-   */
-  override reset(): void {
-    this._isAvailable = undefined;
-    this._isOutputMuted = false;
-    this._frequency = 0;
-    this._outputVolume = 100;
-
-    this.refreshDisplay();
   }
 
   /**

--- a/src/controllers/stationVolume.ts
+++ b/src/controllers/stationVolume.ts
@@ -38,6 +38,7 @@ export class StationVolumeController extends BaseController {
 
   /**
    * Refreshes the title and image on the action.
+   * @remarks This method is debounced with a 100ms delay to prevent excessive updates.
    */
   public override refreshDisplay = debounce(() => {
     this.refreshTitle();

--- a/src/controllers/stationVolume.ts
+++ b/src/controllers/stationVolume.ts
@@ -45,7 +45,8 @@ export class StationVolumeController extends BaseController {
   }, 100);
 
   /**
-   * Gets the not muted SVG template path.
+   * Gets the path to the not muted image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get notMutedTemplatePath(): string {
     return this._notMutedTemplatePath ?? defaultTemplatePath;
@@ -59,7 +60,8 @@ export class StationVolumeController extends BaseController {
   }
 
   /**
-   * Gets the muted SVG template path.
+   * Gets the path to the muted image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get mutedTemplatePath(): string {
     return this._mutedTemplatePath ?? defaultTemplatePath;
@@ -73,7 +75,8 @@ export class StationVolumeController extends BaseController {
   }
 
   /**
-   * Gets the unavailable SVG template path.
+   * Gets the path to the unavailable image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get unavailableTemplatePath(): string {
     return this._unavailableTemplatePath ?? defaultTemplatePath;
@@ -87,8 +90,9 @@ export class StationVolumeController extends BaseController {
   }
 
   /**
-   * Gets the output volume. Returns 100 if undefined.
-   **/
+   * Gets the output volume property.
+   * @returns {number} The output volume. Defaults to 100.
+   */
   get outputVolume(): number {
     return this._outputVolume ?? 100;
   }
@@ -109,7 +113,8 @@ export class StationVolumeController extends BaseController {
   }
 
   /**
-   * Gets whether the output is muted. Returns false if undefined.
+   * Gets the isOutputMuted property.
+   * @returns {boolean} True if the station is muted. Defaults to false.
    */
   get isOutputMuted(): boolean {
     return this._isOutputMuted ?? false;
@@ -129,6 +134,7 @@ export class StationVolumeController extends BaseController {
 
   /**
    * Gets the settings.
+   * @returns {StationVolumeSettings} The settings.
    */
   get settings(): StationVolumeSettings {
     if (this._settings === null) {
@@ -156,16 +162,18 @@ export class StationVolumeController extends BaseController {
   }
 
   /**
-   * Convenience property to get the callsign value of settings.
+   * Gets the callsign value from settings.
+   * @returns {string | undefined} The callsign. Defaults to undefined.
    */
-  get callsign() {
+  get callsign(): string | undefined {
     return this.settings.callsign;
   }
 
   /**
-   * Gets the frequency.
+   * Gets the frequency for the station callsign.
+   * @returns {number} The frequency or 0 if the frequency isn't set.
    */
-  get frequency() {
+  get frequency(): number {
     return this._frequency;
   }
 
@@ -184,7 +192,8 @@ export class StationVolumeController extends BaseController {
   }
 
   /**
-   * True if the station is available in TrackAudio.
+   * Gets the isAvailable value.
+   * @returns {boolean | undefined} True if the station is available in TrackAudio.
    */
   get isAvailable(): boolean | undefined {
     return this._isAvailable;
@@ -203,13 +212,17 @@ export class StationVolumeController extends BaseController {
   }
 
   /**
-   * Convenience property to get the changeAmount value of settings.
+   * Gets the changeAmount.
+   * @returns {number} The amount to change the volume on each dial tick. Defaults to 2.
    */
-  get changeAmount() {
+  get changeAmount(): number {
     const amount = this.settings.changeAmount ?? 2;
     return amount > 0 ? amount : 2;
   }
 
+  /**
+   * Resets the action to defaults and refreshes the display.
+   */
   override reset(): void {
     this._isAvailable = undefined;
     this._isOutputMuted = false;
@@ -219,6 +232,9 @@ export class StationVolumeController extends BaseController {
     this.refreshDisplay();
   }
 
+  /**
+   * Sets the displayed image based on the state of the action.
+   */
   private refreshImage(): void {
     const replacements = {
       volume: this.outputVolume,
@@ -255,6 +271,9 @@ export class StationVolumeController extends BaseController {
     });
   }
 
+  /**
+   * Sets the displayed title based on the state of the action.
+   */
   private refreshTitle(): void {
     if (!trackAudioManager.isVoiceConnected || !this.isAvailable) {
       this.action

--- a/src/controllers/trackAudioStatus.ts
+++ b/src/controllers/trackAudioStatus.ts
@@ -26,6 +26,7 @@ export class TrackAudioStatusController extends BaseController {
   /**
    * Creates a new TrackAudioStatusController.
    * @param action The Stream Deck action object.
+   * @param settings The settings for configuring the track audio status.
    */
   constructor(action: KeyAction, settings: TrackAudioStatusSettings) {
     super(action);
@@ -34,6 +35,7 @@ export class TrackAudioStatusController extends BaseController {
 
   /**
    * Refreshes the title and image on the action.
+   * @remarks This method is debounced with a 100ms delay to prevent excessive updates.
    */
   public override refreshDisplay = debounce(() => {
     this.refreshTitle();

--- a/src/controllers/trackAudioStatus.ts
+++ b/src/controllers/trackAudioStatus.ts
@@ -25,77 +25,85 @@ export class TrackAudioStatusController extends BaseController {
 
   /**
    * Creates a new TrackAudioStatusController.
-   * @param action The Stream Deck action object
+   * @param action The Stream Deck action object.
    */
   constructor(action: KeyAction, settings: TrackAudioStatusSettings) {
     super(action);
     this.settings = settings;
   }
 
+  /**
+   * Refreshes the title and image on the action.
+   */
   public override refreshDisplay = debounce(() => {
     this.refreshTitle();
     this.refreshImage();
   }, 100);
 
+  /**
+   * Resets the action to its default state.
+   */
   public reset() {
     this.refreshDisplay();
   }
 
   //#region Getters and setters
   /**
-   * Returns the showTitle setting, or false if undefined.
+   * Gets the showTitle value from settings.
+   * @returns { boolean } The value. Defaults to true.
    */
-  get showTitle() {
+  get showTitle(): boolean {
     return this.settings.showTitle ?? false;
   }
 
   /**
-   * Convenience method to return the action's title from settings.
+   * Gets the title value from settings.
+   * @returns { string | undefined } The title. Defaults to undefined.
    */
-  get title() {
+  get title(): string | undefined {
     return this.settings.title;
   }
 
   /**
-   * Returns the notConnectedImagePath or the default template path if the
-   * user didn't specify a custom icon.
+   * Gets the path to the not connected image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get notConnectedImagePath(): string {
     return this._notConnectedImagePath ?? defaultTemplatePath;
   }
 
   /**
-   * Sets the notConnectedImagePath and re-compiles the SVG template if necessary.
+   * Sets the notConnectedImagePath.
    */
   set notConnectedImagePath(newValue: string | undefined) {
     this._notConnectedImagePath = stringOrUndefined(newValue);
   }
 
   /**
-   * Returns the connectedImagePath or the default template path if the
-   * user didn't specify a custom icon.
+   * Gets the path to the connected image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get connectedImagePath(): string {
     return this._connectedImagePath ?? defaultTemplatePath;
   }
 
   /**
-   * Sets the notConnectedImagePath and re-compiles the SVG template if necessary.
+   * Sets the connectedImagePath.
    */
   set connectedImagePath(newValue: string | undefined) {
     this._connectedImagePath = stringOrUndefined(newValue);
   }
 
   /**
-   * Returns the voiceConnectedImagePath or the default template path if the
-   * user didn't specify a custom icon.
+   * Gets the path to the voice connected image template.
+   * @returns {string} The path specified by the user, or the defaultTemplatePath if none was specified.
    */
   get voiceConnectedImagePath(): string {
     return this._voiceConnectedImagePath ?? defaultTemplatePath;
   }
 
   /**
-   * Sets the notConnectedImagePath and re-compiles the SVG template if necessary.
+   * Sets the voiceConnectedImagePath.
    */
   set voiceConnectedImagePath(newValue: string | undefined) {
     this._voiceConnectedImagePath = stringOrUndefined(newValue);
@@ -103,6 +111,7 @@ export class TrackAudioStatusController extends BaseController {
 
   /**
    * Gets the settings.
+   * @returns {TrackAudioStatusSettings} The settings.
    */
   get settings() {
     if (this._settings === null) {
@@ -130,7 +139,7 @@ export class TrackAudioStatusController extends BaseController {
   //#endregion
 
   /**
-   * Sets the title on the action.
+   * Sets the displayed title based on the state of the action.
    */
   private refreshTitle() {
     const title = new TitleBuilder();
@@ -141,7 +150,7 @@ export class TrackAudioStatusController extends BaseController {
   }
 
   /**
-   * Sets the action image based on the isConnected state
+   * Sets the displayed image based on the state of the action.
    */
   private refreshImage() {
     const replacements = {

--- a/src/events/streamDeck/stationStatus/addStation.ts
+++ b/src/events/streamDeck/stationStatus/addStation.ts
@@ -1,4 +1,4 @@
-import { StationSettings } from "@actions/stationStatus";
+import { StationStatusSettings } from "@actions/stationStatus";
 import { StationStatusController } from "@controllers/stationStatus";
 import { KeyAction } from "@elgato/streamdeck";
 import actionManager from "@managers/action";
@@ -11,7 +11,7 @@ import actionManager from "@managers/action";
  */
 export const handleAddStation = (
   action: KeyAction,
-  settings: StationSettings
+  settings: StationStatusSettings
 ) => {
   const controller = new StationStatusController(action, settings);
 

--- a/src/events/streamDeck/stationStatus/updateStation.ts
+++ b/src/events/streamDeck/stationStatus/updateStation.ts
@@ -1,4 +1,4 @@
-import { StationSettings } from "@actions/stationStatus";
+import { StationStatusSettings } from "@actions/stationStatus";
 import { KeyAction } from "@elgato/streamdeck";
 import actionManager from "@managers/action";
 
@@ -11,7 +11,7 @@ import actionManager from "@managers/action";
  */
 export const handleUpdateStation = (
   action: KeyAction,
-  settings: StationSettings
+  settings: StationStatusSettings
 ) => {
   const savedAction = actionManager
     .getStationStatusControllers()


### PR DESCRIPTION
Fixes #364 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Renamed `StationSettings` to `StationStatusSettings` across multiple files
	- Updated type references and method signatures in various controllers and event handlers
	- Improved code documentation and type clarity

- **Bug Fixes**
	- Added explicit return types to multiple getter methods
	- Enhanced error handling in some methods

- **Chores**
	- Simplified and clarified code comments
	- Added new `reset()` methods to several controllers
	- Consolidated template path variables in some controllers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->