### PR TITLE
Update doc url in manifest

### DIFF
--- a/com.neil-enns.trackaudio.sdPlugin/manifest.json
+++ b/com.neil-enns.trackaudio.sdPlugin/manifest.json
@@ -140,7 +140,7 @@
   "Description": "Provides buttons for controlling TrackAudio",
   "Icon": "images/plugin/pluginIcon",
   "SDKVersion": 2,
-  "URL": "https://github.com/neilenns/streamdeck-trackaudio",
+  "URL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/",
   "Software": {
     "MinimumVersion": "6.5"
   },


### PR DESCRIPTION
Fixes #391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated plugin documentation URL to point to a new documentation page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->