### PR TITLE
Add mute on long press option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,7 @@
     "streamdeck",
     "trackaudio",
     "Typeguard",
+    "UNICOM",
     "vatsim"
   ]
 }

--- a/com.neil-enns.trackaudio.sdPlugin/pi/stationStatus.html
+++ b/com.neil-enns.trackaudio.sdPlugin/pi/stationStatus.html
@@ -43,7 +43,14 @@
     <sdpi-item>
       <sdpi-checkbox
         setting="toggleMuteOnPress"
-        label="Toggle mute when pressed"
+        label="Toggle mute on press"
+      ></sdpi-checkbox>
+    </sdpi-item>
+
+    <sdpi-item>
+      <sdpi-checkbox
+        setting="toggleMuteOnLongPress"
+        label="Toggle mute on long press"
       ></sdpi-checkbox>
     </sdpi-item>
 

--- a/src/actions/stationStatus.ts
+++ b/src/actions/stationStatus.ts
@@ -102,6 +102,7 @@ export interface StationStatusSettings {
   showListenTo?: boolean;
   showTitle?: boolean;
   title?: string;
+  toggleMuteOnLongPress?: boolean;
   toggleMuteOnPress?: boolean;
   unavailableImagePath?: string;
   [key: string]: JsonValue;

--- a/src/controllers/stationStatus.ts
+++ b/src/controllers/stationStatus.ts
@@ -238,6 +238,14 @@ export class StationStatusController extends BaseController {
   }
 
   /**
+   * Gets the toggleMuteOnLongPress value from settings.
+   * @returns {boolean} The value. Defaults to false.
+   */
+  get toggleMuteOnLongPress(): boolean {
+    return this.settings.toggleMuteOnLongPress ?? false;
+  }
+
+  /**
    * Gets the toggleMuteOnPress value from settings.
    * @returns {boolean} The value. Defaults to false.
    */

--- a/src/events/streamDeck/stationStatus/stationStatusLongPress.ts
+++ b/src/events/streamDeck/stationStatus/stationStatusLongPress.ts
@@ -4,8 +4,8 @@ import trackAudioManager from "@managers/trackAudio";
 import { handleAsyncException } from "@utils/handleAsyncException";
 
 /**
- * Called when a station status action has a long press. Resets the
- * station status and refreshes its state.
+ * Called when a station status action has a long press.
+ * Either toggles mute or refreshes the station status depending on the user's setting.
  * @param actionId The ID of the action that had the long press
  */
 export const handleStationStatusLongPress = (action: KeyAction) => {
@@ -34,7 +34,7 @@ export const handleStationStatusLongPress = (action: KeyAction) => {
     return;
   }
 
-  // Otherwise reset and refresh
+  // If mute toggle isn't enabled, refresh the station state.
   savedAction.reset();
   trackAudioManager.refreshStationState(savedAction.callsign);
 

--- a/src/events/streamDeck/stationStatus/stationStatusLongPress.ts
+++ b/src/events/streamDeck/stationStatus/stationStatusLongPress.ts
@@ -5,7 +5,7 @@ import { handleAsyncException } from "@utils/handleAsyncException";
 
 /**
  * Called when a station status action has a long press. Resets the
- * station status and refreshses its state.
+ * station status and refreshes its state.
  * @param actionId The ID of the action that had the long press
  */
 export const handleStationStatusLongPress = (action: KeyAction) => {
@@ -17,6 +17,24 @@ export const handleStationStatusLongPress = (action: KeyAction) => {
     return;
   }
 
+  // Mute if that's the requested action.
+  if (savedAction.toggleMuteOnLongPress) {
+    trackAudioManager.sendMessage({
+      type: "kSetStationState",
+      value: {
+        frequency: savedAction.frequency,
+        isOutputMuted: "toggle",
+        rx: undefined,
+        tx: undefined,
+        xc: undefined,
+        xca: undefined,
+        headset: undefined,
+      },
+    });
+    return;
+  }
+
+  // Otherwise reset and refresh
   savedAction.reset();
   trackAudioManager.refreshStationState(savedAction.callsign);
 

--- a/src/managers/action.ts
+++ b/src/managers/action.ts
@@ -68,8 +68,12 @@ class ActionManager extends EventEmitter {
 
     // Add on all the hotline action callsigns
     this.getHotlineControllers().forEach((hotline) => {
-      trackedCallsignsSet.add(hotline.primaryCallsign);
-      trackedCallsignsSet.add(hotline.hotlineCallsign);
+      if (hotline.primaryCallsign) {
+        trackedCallsignsSet.add(hotline.primaryCallsign);
+      }
+      if (hotline.hotlineCallsign) {
+        trackedCallsignsSet.add(hotline.hotlineCallsign);
+      }
     });
 
     // Auto-add all tracked callsigns with a 250ms delay between each message


### PR DESCRIPTION
Fixes #395

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added option to toggle mute on long press for station status.
	- Introduced a new checkbox for toggling mute functionality on long press.

- **Bug Fixes**
	- Improved error handling for adding hotline action callsigns.

- **Documentation**
	- Minor comment correction in long press event handler.

- **Chores**
	- Added "UNICOM" to custom spell-check dictionary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->