### PR TITLE
Add an option to toggle speaker on press

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,7 @@
     "callsigns",
     "coms",
     "elgato",
+    "spkr",
     "stationstatus",
     "stationvolume",
     "streamdeck",

--- a/com.neil-enns.trackaudio.sdPlugin/pi/stationStatus.html
+++ b/com.neil-enns.trackaudio.sdPlugin/pi/stationStatus.html
@@ -54,6 +54,20 @@
       ></sdpi-checkbox>
     </sdpi-item>
 
+    <sdpi-item>
+      <sdpi-checkbox
+        setting="toggleSpeakerOnPress"
+        label="Toggle speaker on press"
+      ></sdpi-checkbox>
+    </sdpi-item>
+
+    <sdpi-item>
+      <sdpi-checkbox
+        setting="toggleSpeakerOnLongPress"
+        label="Toggle speaker on long press"
+      ></sdpi-checkbox>
+    </sdpi-item>
+
     <sdpi-item label="Active comms">
       <sdpi-file
         setting="activeCommsImagePath"

--- a/src/actions/stationStatus.ts
+++ b/src/actions/stationStatus.ts
@@ -104,6 +104,8 @@ export interface StationStatusSettings {
   title?: string;
   toggleMuteOnLongPress?: boolean;
   toggleMuteOnPress?: boolean;
+  toggleSpeakerOnLongPress?: boolean;
+  toggleSpeakerOnPress?: boolean;
   unavailableImagePath?: string;
   [key: string]: JsonValue;
 }

--- a/src/controllers/stationStatus.ts
+++ b/src/controllers/stationStatus.ts
@@ -546,9 +546,9 @@ export class StationStatusController extends BaseController {
   //#endregion
 
   //#region Websocket messages
-  /// <summary>
-  /// Toggles the mute state of the station.
-  /// </summary>
+  /**
+   * Toggles the mute state of the station.
+   */
   public toggleMute() {
     trackAudioManager.sendMessage({
       type: "kSetStationState",
@@ -564,9 +564,9 @@ export class StationStatusController extends BaseController {
     });
   }
 
-  /// <summary>
-  /// Toggles the speaker state of the station.
-  /// </summary>
+  /**
+   * Toggles the speaker state of the station.
+   */
   public toggleSpeaker() {
     trackAudioManager.sendMessage({
       type: "kSetStationState",
@@ -582,9 +582,9 @@ export class StationStatusController extends BaseController {
     });
   }
 
-  /// <summary>
-  /// Toggles the state of the listenTo button.
-  /// </summary>
+  /**
+   * Toggles the listenTo button on the action.
+   */
   public toggleListenTo() {
     trackAudioManager.sendMessage({
       type: "kSetStationState",

--- a/src/controllers/stationStatus.ts
+++ b/src/controllers/stationStatus.ts
@@ -254,6 +254,22 @@ export class StationStatusController extends BaseController {
   }
 
   /**
+   * Gets the toggleSpeakerOnLongPress value from settings.
+   * @returns {boolean} The value. Defaults to false.
+   */
+  get toggleSpeakerOnLongPress(): boolean {
+    return this.settings.toggleSpeakerOnLongPress ?? false;
+  }
+
+  /**
+   * Gets the toggleSpeakerOnPress value from settings.
+   * @returns {boolean} The value. Defaults to false.
+   */
+  get toggleSpeakerOnPress(): boolean {
+    return this.settings.toggleSpeakerOnPress ?? false;
+  }
+
+  /**
    * Gets the isListeningForReceive property.
    * @returns {boolean}  Returns true if listenTo is rx, xc, or xca,
    * the settings that mean rx is active in TrackAudio.
@@ -527,6 +543,63 @@ export class StationStatusController extends BaseController {
       : [];
     return entries;
   }
+  //#endregion
+
+  //#region Websocket messages
+  /// <summary>
+  /// Toggles the mute state of the station.
+  /// </summary>
+  public toggleMute() {
+    trackAudioManager.sendMessage({
+      type: "kSetStationState",
+      value: {
+        frequency: this.frequency,
+        isOutputMuted: "toggle",
+        rx: undefined,
+        tx: undefined,
+        xc: undefined,
+        xca: undefined,
+        headset: undefined,
+      },
+    });
+  }
+
+  /// <summary>
+  /// Toggles the speaker state of the station.
+  /// </summary>
+  public toggleSpeaker() {
+    trackAudioManager.sendMessage({
+      type: "kSetStationState",
+      value: {
+        frequency: this.frequency,
+        isOutputMuted: undefined,
+        rx: undefined,
+        tx: undefined,
+        xc: undefined,
+        xca: undefined,
+        headset: "toggle",
+      },
+    });
+  }
+
+  /// <summary>
+  /// Toggles the state of the listenTo button.
+  /// </summary>
+  public toggleListenTo() {
+    trackAudioManager.sendMessage({
+      type: "kSetStationState",
+      value: {
+        frequency: this.frequency,
+        rx: this.listenTo === "rx" ? "toggle" : undefined,
+        tx: this.listenTo === "tx" ? "toggle" : undefined,
+        xc: this.listenTo === "xc" ? "toggle" : undefined,
+        xca: this.listenTo === "xca" ? "toggle" : undefined,
+        headset: undefined,
+        isOutputMuted: undefined,
+      },
+    });
+  }
+
   //#endregion
 
   /**

--- a/src/events/streamDeck/stationStatus/stationStatusLongPress.ts
+++ b/src/events/streamDeck/stationStatus/stationStatusLongPress.ts
@@ -9,34 +9,28 @@ import { handleAsyncException } from "@utils/handleAsyncException";
  * @param actionId The ID of the action that had the long press
  */
 export const handleStationStatusLongPress = (action: KeyAction) => {
-  const savedAction = actionManager
+  const foundAction = actionManager
     .getStationStatusControllers()
     .find((entry) => entry.action.id === action.id);
 
-  if (!savedAction) {
+  if (!foundAction) {
     return;
   }
 
   // Mute if that's the requested action.
-  if (savedAction.toggleMuteOnLongPress) {
-    trackAudioManager.sendMessage({
-      type: "kSetStationState",
-      value: {
-        frequency: savedAction.frequency,
-        isOutputMuted: "toggle",
-        rx: undefined,
-        tx: undefined,
-        xc: undefined,
-        xca: undefined,
-        headset: undefined,
-      },
-    });
+  if (foundAction.toggleMuteOnLongPress) {
+    foundAction.toggleMute();
     return;
   }
 
-  // If mute toggle isn't enabled, refresh the station state.
-  savedAction.reset();
-  trackAudioManager.refreshStationState(savedAction.callsign);
+  if (foundAction.toggleSpeakerOnLongPress) {
+    foundAction.toggleSpeaker();
+    return;
+  }
+
+  // If mute or speaker toggle isn't enabled, refresh the station state.
+  foundAction.reset();
+  trackAudioManager.refreshStationState(foundAction.callsign);
 
   action.showOk().catch((error: unknown) => {
     handleAsyncException("Unable to show OK on station status button:", error);

--- a/src/events/streamDeck/stationStatus/stationStatusLongPress.ts
+++ b/src/events/streamDeck/stationStatus/stationStatusLongPress.ts
@@ -20,17 +20,21 @@ export const handleStationStatusLongPress = (action: KeyAction) => {
   // Mute if that's the requested action.
   if (foundAction.toggleMuteOnLongPress) {
     foundAction.toggleMute();
-    return;
   }
 
+  // Speaker if that's the requested action.
   if (foundAction.toggleSpeakerOnLongPress) {
     foundAction.toggleSpeaker();
-    return;
   }
 
   // If mute or speaker toggle isn't enabled, refresh the station state.
-  foundAction.reset();
-  trackAudioManager.refreshStationState(foundAction.callsign);
+  if (
+    !foundAction.toggleMuteOnLongPress &&
+    !foundAction.toggleSpeakerOnLongPress
+  ) {
+    foundAction.reset();
+    trackAudioManager.refreshStationState(foundAction.callsign);
+  }
 
   action.showOk().catch((error: unknown) => {
     handleAsyncException("Unable to show OK on station status button:", error);

--- a/src/events/streamDeck/stationStatus/stationStatusShortPress.ts
+++ b/src/events/streamDeck/stationStatus/stationStatusShortPress.ts
@@ -24,14 +24,15 @@ export const handleStationStatusShortPress = (action: KeyAction) => {
   // Mute if that's the requested action.
   if (foundAction.toggleMuteOnPress) {
     foundAction.toggleMute();
-    return;
   }
 
+  // Toggle speaker if that's the requested action.
   if (foundAction.toggleSpeakerOnPress) {
     foundAction.toggleSpeaker();
-    return;
   }
 
   // If mute or speaker isn't set then toggle listenTo.
-  foundAction.toggleListenTo();
+  if (!foundAction.toggleMuteOnPress && !foundAction.toggleSpeakerOnPress) {
+    foundAction.toggleListenTo();
+  }
 };

--- a/src/events/streamDeck/stationStatus/stationStatusShortPress.ts
+++ b/src/events/streamDeck/stationStatus/stationStatusShortPress.ts
@@ -1,7 +1,6 @@
 import { isStationStatusController } from "@controllers/stationStatus";
 import { KeyAction } from "@elgato/streamdeck";
 import actionManager from "@managers/action";
-import trackAudioManager from "@managers/trackAudio";
 
 /**
  * Handles a short press of a station status action. Toggles the
@@ -24,32 +23,15 @@ export const handleStationStatusShortPress = (action: KeyAction) => {
 
   // Mute if that's the requested action.
   if (foundAction.toggleMuteOnPress) {
-    trackAudioManager.sendMessage({
-      type: "kSetStationState",
-      value: {
-        frequency: foundAction.frequency,
-        isOutputMuted: "toggle",
-        rx: undefined,
-        tx: undefined,
-        xc: undefined,
-        xca: undefined,
-        headset: undefined,
-      },
-    });
+    foundAction.toggleMute();
     return;
   }
 
-  // Send the message to TrackAudio.
-  trackAudioManager.sendMessage({
-    type: "kSetStationState",
-    value: {
-      frequency: foundAction.frequency,
-      rx: foundAction.listenTo === "rx" ? "toggle" : undefined,
-      tx: foundAction.listenTo === "tx" ? "toggle" : undefined,
-      xc: foundAction.listenTo === "xc" ? "toggle" : undefined,
-      xca: foundAction.listenTo === "xca" ? "toggle" : undefined,
-      headset: undefined,
-      isOutputMuted: undefined,
-    },
-  });
+  if (foundAction.toggleSpeakerOnPress) {
+    foundAction.toggleSpeaker();
+    return;
+  }
+
+  // If mute or speaker isn't set then toggle listenTo.
+  foundAction.toggleListenTo();
 };


### PR DESCRIPTION
Fixes #402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added options to toggle speaker on press and long press for station status.
  - Introduced new methods to control station audio settings, including mute and speaker toggles.

- **Improvements**
  - Streamlined handling of short and long press actions for station status.
  - Enhanced flexibility in managing audio state changes.

- **User Interface**
  - Added new checkbox settings for speaker toggle functionality in station status configuration.
  
- **Spell Checker**
  - Added the word "spkr" to the recognized words list for improved spell checking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->