### PR TITLE
Automatically add stations on profile change

### DIFF
--- a/src/events/action/stationStatusAdded.ts
+++ b/src/events/action/stationStatusAdded.ts
@@ -1,10 +1,12 @@
 import { StationStatusController } from "@controllers/stationStatus";
 import trackAudioManager from "@managers/trackAudio";
+import actionManager from "@managers/action";
 
 export const handleStationStatusAdded = (
   controller: StationStatusController
 ) => {
   if (trackAudioManager.isConnected) {
     trackAudioManager.refreshStationState(controller.callsign);
+    actionManager.trackProfileChanged();
   }
 };

--- a/src/managers/action.ts
+++ b/src/managers/action.ts
@@ -40,6 +40,7 @@ class ActionManager extends EventEmitter {
   private static instance: ActionManager | null = null;
   private actions: Controller[] = [];
   private profileChangedTimeout: NodeJS.Timeout | undefined;
+  private static readonly PROFILE_CHANGE_DELAY_MS = 500; // Number of milliseconds to wait before auto-adding stations after a profile change
 
   private constructor() {
     super();
@@ -65,7 +66,7 @@ class ActionManager extends EventEmitter {
       this.autoAddStations().catch((error: unknown) => {
         handleAsyncException("Error auto-adding stations", error);
       });
-    }, 500);
+    }, ActionManager.PROFILE_CHANGE_DELAY_MS);
   }
 
   /**


### PR DESCRIPTION
Fixes #420

* Automatically adds stations to TrackAudio when the Stream Deck profile changes and TrackAudio is connected
* Adds additional tests to reduce the number of station add requests sent to TrackAudio: already active stations and stations without a callsign are no longer sent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced profile tracking now automatically processes station updates when connectivity is active, ensuring timely adjustments.
  - Introduced an automated mechanism for station updates that refines the selection process to include only eligible entries.
  - Improved error handling for a smoother and more reliable operational experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->