### PR TITLE
Add a push to mute setting to the volume action

### DIFF
--- a/com.neil-enns.trackaudio.sdPlugin/pi/stationVolume.html
+++ b/com.neil-enns.trackaudio.sdPlugin/pi/stationVolume.html
@@ -53,6 +53,11 @@
           label="Push to toggle mute"
           default="true"
         ></sdpi-checkbox>
+        <sdpi-checkbox
+          setting="tapToMute"
+          label="Tap to toggle mute"
+          default="true"
+        ></sdpi-checkbox>
       </details>
     </sdpi-item>
   </body>

--- a/com.neil-enns.trackaudio.sdPlugin/pi/stationVolume.html
+++ b/com.neil-enns.trackaudio.sdPlugin/pi/stationVolume.html
@@ -44,5 +44,16 @@
         accept="image/png, image/jpeg, image/svg+xml"
       ></sdpi-file>
     </sdpi-item>
+
+    <sdpi-item>
+      <details class="sdpi-item-value">
+        <summary>Advanced options</summary>
+        <sdpi-checkbox
+          setting="pushToMute"
+          label="Push to toggle mute"
+          default="true"
+        ></sdpi-checkbox>
+      </details>
+    </sdpi-item>
   </body>
 </html>

--- a/src/actions/stationVolume.ts
+++ b/src/actions/stationVolume.ts
@@ -96,5 +96,6 @@ export interface StationVolumeSettings {
   changeAmount?: number;
   mutedImagePath?: string;
   notMutedImagePath?: string;
+  pushToMute?: boolean;
   [key: string]: JsonValue;
 }

--- a/src/actions/stationVolume.ts
+++ b/src/actions/stationVolume.ts
@@ -68,7 +68,7 @@ export class StationVolume extends SingletonAction<StationVolumeSettings> {
       return;
     }
 
-    handleStationVolumeDialPress(ev.action);
+    handleStationVolumeDialPress(ev.action, "press");
   }
 
   override onTouchTap(
@@ -80,7 +80,7 @@ export class StationVolume extends SingletonAction<StationVolumeSettings> {
       return;
     }
 
-    handleStationVolumeDialPress(ev.action);
+    handleStationVolumeDialPress(ev.action, "tap");
   }
 
   override onWillDisappear(
@@ -97,5 +97,6 @@ export interface StationVolumeSettings {
   mutedImagePath?: string;
   notMutedImagePath?: string;
   pushToMute?: boolean;
+  tapToMute?: boolean;
   [key: string]: JsonValue;
 }

--- a/src/controllers/stationVolume.ts
+++ b/src/controllers/stationVolume.ts
@@ -154,6 +154,14 @@ export class StationVolumeController extends BaseController {
   }
 
   /**
+   * Gets the tapToMute setting.
+   * @returns {boolean} True if tap to mute is enabled. Defaults to true.
+   */
+  get tapToMute(): boolean {
+    return this._settings?.tapToMute ?? true;
+  }
+
+  /**
    * Gets the settings.
    * @returns {StationVolumeSettings} The settings.
    */

--- a/src/controllers/stationVolume.ts
+++ b/src/controllers/stationVolume.ts
@@ -146,6 +146,14 @@ export class StationVolumeController extends BaseController {
   }
 
   /**
+   * Gets the pushToMute setting.
+   * @returns {boolean} True if push to mute is enabled. Defaults to true.
+   */
+  get pushToMute(): boolean {
+    return this._settings?.pushToMute ?? true;
+  }
+
+  /**
    * Gets the settings.
    * @returns {StationVolumeSettings} The settings.
    */

--- a/src/events/streamDeck/stationVolume/stationVolumeDialPress.ts
+++ b/src/events/streamDeck/stationVolume/stationVolumeDialPress.ts
@@ -1,6 +1,9 @@
 import { DialAction } from "@elgato/streamdeck";
 import actionManager from "@managers/action";
 import trackAudioManager from "@managers/trackAudio";
+import mainLogger from "@utils/logger";
+
+const logger = mainLogger.child({ service: "stationVolume" });
 
 /**
  * Toggles the mute setting on the station.
@@ -12,6 +15,15 @@ export const handleStationVolumeDialPress = (action: DialAction) => {
     .find((entry) => entry.action.id === action.id);
 
   if (!savedAction) {
+    return;
+  }
+
+  if (!savedAction.pushToMute) {
+    logger.info(
+      `Station volume action ${
+        savedAction.callsign ?? "undefined"
+      } does not have push to mute enabled.`
+    );
     return;
   }
 

--- a/src/events/streamDeck/stationVolume/stationVolumeDialPress.ts
+++ b/src/events/streamDeck/stationVolume/stationVolumeDialPress.ts
@@ -9,7 +9,10 @@ const logger = mainLogger.child({ service: "stationVolume" });
  * Toggles the mute setting on the station.
  * @param action The action that triggered the press
  */
-export const handleStationVolumeDialPress = (action: DialAction) => {
+export const handleStationVolumeDialPress = (
+  action: DialAction,
+  trigger: "press" | "tap"
+) => {
   const savedAction = actionManager
     .getStationVolumeControllers()
     .find((entry) => entry.action.id === action.id);
@@ -18,11 +21,20 @@ export const handleStationVolumeDialPress = (action: DialAction) => {
     return;
   }
 
-  if (!savedAction.pushToMute) {
+  if (!savedAction.pushToMute && trigger === "press") {
     logger.info(
       `Station volume action ${
         savedAction.callsign ?? "undefined"
       } does not have push to mute enabled.`
+    );
+    return;
+  }
+
+  if (!savedAction.tapToMute && trigger === "tap") {
+    logger.info(
+      `Station volume action ${
+        savedAction.callsign ?? "undefined"
+      } does not have tap to mute enabled.`
     );
     return;
   }

--- a/src/events/vatsim/vatsimDataReceived.ts
+++ b/src/events/vatsim/vatsimDataReceived.ts
@@ -14,7 +14,7 @@ export const handleVatsimDataReceived = (data: VatsimData) => {
     }
 
     // Look for the callsign in the returned ATIS info. If it's found set the letter.
-    // If not set the isUnavialable flag to show the error to the user.
+    // If not set the isUnavailable flag to show the error to the user.
     if (action.callsign in atisInfo) {
       action.isUnavailable = false;
       action.letter = atisInfo[action.callsign].atis_code;


### PR DESCRIPTION
Fixes #435

New setting, on by default, for "Push to toggle mute" on the dial actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added an "Advanced options" section in settings with checkboxes for "Push to mute" and "Tap to mute," both enabled by default.
	- Users can now toggle mute functionality via push or tap actions on the dial based on these new settings.

- **Bug Fixes**
	- Fixed a typo in a comment for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->