### PR TITLE
Change Renovate schedule to monthly and remove automerge type

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "schedule:weekly",
-    "schedule:automergeWeekly"
+    "schedule:monthly",
+    "schedule:automergeMonthly"
   ],
   "labels": [
     "dependencies"
@@ -15,7 +15,6 @@
         "devDependencies"
       ],
       "automerge": true,
-      "automergeType": "branch",
       "matchPackageNames": [
         "@types/{/,}**"
       ]
@@ -31,7 +30,6 @@
         "patch"
       ],
       "automerge": true,
-      "automergeType": "branch",
       "matchPackageNames": [
         "eslint-plugin{/,}**"
       ]
@@ -45,7 +43,6 @@
       ],
       "matchCurrentVersion": "!/^0/",
       "automerge": true,
-      "automergeType": "branch",
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management schedule: Renovate updates and automerges now run monthly instead of weekly, reducing churn while keeping dependencies current.
  * Streamlined automerge settings by removing explicit merge strategy; automerge remains enabled for eligible updates.
  * Maintenance-only change with no impact on product features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->