### PR TITLE
Migrate to sdk v2 and enable DRM

### DIFF
--- a/com.neil-enns.trackaudio.sdPlugin/manifest.json
+++ b/com.neil-enns.trackaudio.sdPlugin/manifest.json
@@ -165,7 +165,7 @@
 	"CodePath": "bin/plugin.js",
 	"Description": "Provides buttons for controlling TrackAudio",
 	"Icon": "images/plugin/pluginIcon",
-	"SDKVersion": 2,
+	"SDKVersion": 3,
 	"URL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/",
 	"Software": {
 		"MinimumVersion": "6.9"

--- a/com.neil-enns.trackaudio.sdPlugin/manifest.json
+++ b/com.neil-enns.trackaudio.sdPlugin/manifest.json
@@ -1,188 +1,170 @@
 {
-	"$schema": "https://schemas.elgato.com/streamdeck/plugins/manifest.json",
-	"Name": "TrackAudio",
-	"Version": "0.1.0.0",
-	"Author": "Neil Enns",
-	"SupportURL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/",
-	"Actions": [
-		{
-			"Name": "Main volume",
-			"UUID": "com.neil-enns.trackaudio.mainvolume",
-			"Icon": "images/plugin/volume",
-			"PropertyInspectorPath": "pi/mainVolume.html",
-			"Tooltip": "Controls the main volume for TrackAudio.",
-			"SupportURL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/main-volume/",
-			"Controllers": [
-				"Encoder"
-			],
-			"Encoder": {
-				"layout": "$B1",
-				"TriggerDescription": {
-					"Push": "Toggle mute",
-					"Rotate": "Adjust volume"
-				}
-			},
-			"DisableAutomaticStates": true,
-			"States": [
-				{
-					"Image": "images/actions/default",
-					"TitleAlignment": "middle"
-				}
-			]
-		},
-		{
-			"Name": "Station volume",
-			"UUID": "com.neil-enns.trackaudio.stationvolume",
-			"Icon": "images/plugin/volume",
-			"PropertyInspectorPath": "pi/stationVolume.html",
-			"Tooltip": "Controls the volume for the specified station.",
-			"SupportURL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/station-status/",
-			"Controllers": [
-				"Encoder"
-			],
-			"Encoder": {
-				"layout": "$B1",
-				"TriggerDescription": {
-					"Push": "Toggle mute",
-					"Touch": "Toggle mute",
-					"Rotate": "Adjust volume"
-				}
-			},
-			"DisableAutomaticStates": true,
-			"States": [
-				{
-					"Image": "images/actions/default",
-					"TitleAlignment": "middle"
-				}
-			]
-		},
-		{
-			"Name": "ATIS letter",
-			"UUID": "com.neil-enns.trackaudio.atisletter",
-			"Icon": "images/actions/atisLetter/cloud-white",
-			"PropertyInspectorPath": "pi/atisLetter.html",
-			"Tooltip": "Shows the current ATIS letter for the specified station.",
-			"SupportURL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/atis-letter/",
-			"Controllers": [
-				"Keypad"
-			],
-			"DisableAutomaticStates": true,
-			"UserTitleEnabled": false,
-			"States": [
-				{
-					"Image": "images/actions/default",
-					"TitleAlignment": "middle"
-				}
-			]
-		},
-		{
-			"Name": "Hotline",
-			"UUID": "com.neil-enns.trackaudio.hotline",
-			"Icon": "images/plugin/phone-solid",
-			"Tooltip": "Toggles Tx for a hotline frequency.",
-			"SupportURL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/hotline/",
-			"PropertyInspectorPath": "pi/hotline.html",
-			"DisableAutomaticStates": true,
-			"UserTitleEnabled": false,
-			"Controllers": [
-				"Keypad"
-			],
-			"States": [
-				{
-					"Image": "images/actions/default",
-					"TitleAlignment": "bottom"
-				}
-			]
-		},
-		{
-			"Name": "Push to talk",
-			"UUID": "com.neil-enns.trackaudio.pushtotalk",
-			"Icon": "images/plugin/microphone-solid",
-			"Tooltip": "Triggers transmit via push-to-talk.",
-			"SupportURL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/push-to-talk/",
-			"DisableAutomaticStates": true,
-			"UserTitleEnabled": false,
-			"PropertyInspectorPath": "pi/pushToTalk.html",
-			"Controllers": [
-				"Keypad"
-			],
-			"States": [
-				{
-					"Image": "images/actions/default",
-					"TitleAlignment": "middle"
-				}
-			]
-		},
-		{
-			"Name": "Station status",
-			"UUID": "com.neil-enns.trackaudio.stationstatus",
-			"Icon": "images/plugin/headphones-solid",
-			"Tooltip": "Shows the status of a station.",
-			"SupportURL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/station-status/",
-			"DisableAutomaticStates": true,
-			"Controllers": [
-				"Keypad"
-			],
-			"PropertyInspectorPath": "pi/stationStatus.html",
-			"UserTitleEnabled": false,
-			"States": [
-				{
-					"Image": "images/actions/default",
-					"TitleAlignment": "middle"
-				}
-			]
-		},
-		{
-			"Name": "TrackAudio status",
-			"UUID": "com.neil-enns.trackaudio.trackaudiostatus",
-			"Icon": "images/actions/trackAudioStatus/pluginIcon",
-			"Tooltip": "Shows the status of the connection to TrackAudio.",
-			"SupportURL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/trackaudio-status/",
-			"PropertyInspectorPath": "pi/trackAudioStatus.html",
-			"DisableAutomaticStates": true,
-			"UserTitleEnabled": false,
-			"Controllers": [
-				"Keypad"
-			],
-			"States": [
-				{
-					"Image": "images/actions/default",
-					"TitleAlignment": "middle"
-				}
-			]
-		}
-	],
-	"ApplicationsToMonitor": {
-		"mac": [
-			"com.vatsim.trackaudio"
-		],
-		"windows": [
-			"trackaudio.exe"
-		]
-	},
-	"Category": "TrackAudio",
-	"CategoryIcon": "images/plugin/categoryIcon",
-	"CodePath": "bin/plugin.js",
-	"Description": "Provides buttons for controlling TrackAudio",
-	"Icon": "images/plugin/pluginIcon",
-	"SDKVersion": 3,
-	"URL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/",
-	"Software": {
-		"MinimumVersion": "6.9"
-	},
-	"OS": [
-		{
-			"Platform": "mac",
-			"MinimumVersion": "10.15"
-		},
-		{
-			"Platform": "windows",
-			"MinimumVersion": "10"
-		}
-	],
-	"Nodejs": {
-		"Version": "20",
-		"Debug": "--inspect=127.0.0.1:54545"
-	},
-	"UUID": "com.neil-enns.trackaudio"
+  "$schema": "https://schemas.elgato.com/streamdeck/plugins/manifest.json",
+  "Name": "TrackAudio",
+  "Version": "0.1.0.0",
+  "Author": "Neil Enns",
+  "SupportURL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/",
+  "Actions": [
+    {
+      "Name": "Main volume",
+      "UUID": "com.neil-enns.trackaudio.mainvolume",
+      "Icon": "images/plugin/volume",
+      "PropertyInspectorPath": "pi/mainVolume.html",
+      "Tooltip": "Controls the main volume for TrackAudio.",
+      "SupportURL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/main-volume/",
+      "Controllers": ["Encoder"],
+      "Encoder": {
+        "layout": "$B1",
+        "TriggerDescription": {
+          "Push": "Toggle mute",
+          "Rotate": "Adjust volume"
+        }
+      },
+      "DisableAutomaticStates": true,
+      "States": [
+        {
+          "Image": "images/actions/default",
+          "TitleAlignment": "middle"
+        }
+      ]
+    },
+    {
+      "Name": "Station volume",
+      "UUID": "com.neil-enns.trackaudio.stationvolume",
+      "Icon": "images/plugin/volume",
+      "PropertyInspectorPath": "pi/stationVolume.html",
+      "Tooltip": "Controls the volume for the specified station.",
+      "SupportURL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/station-volume/",
+      "Controllers": ["Encoder"],
+      "Encoder": {
+        "layout": "$B1",
+        "TriggerDescription": {
+          "Push": "Toggle mute",
+          "Touch": "Toggle mute",
+          "Rotate": "Adjust volume"
+        }
+      },
+      "DisableAutomaticStates": true,
+      "States": [
+        {
+          "Image": "images/actions/default",
+          "TitleAlignment": "middle"
+        }
+      ]
+    },
+    {
+      "Name": "ATIS letter",
+      "UUID": "com.neil-enns.trackaudio.atisletter",
+      "Icon": "images/actions/atisLetter/cloud-white",
+      "PropertyInspectorPath": "pi/atisLetter.html",
+      "Tooltip": "Shows the current ATIS letter for the specified station.",
+      "SupportURL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/atis-letter/",
+      "Controllers": ["Keypad"],
+      "DisableAutomaticStates": true,
+      "UserTitleEnabled": false,
+      "States": [
+        {
+          "Image": "images/actions/default",
+          "TitleAlignment": "middle"
+        }
+      ]
+    },
+    {
+      "Name": "Hotline",
+      "UUID": "com.neil-enns.trackaudio.hotline",
+      "Icon": "images/plugin/phone-solid",
+      "Tooltip": "Toggles Tx for a hotline frequency.",
+      "SupportURL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/hotline/",
+      "PropertyInspectorPath": "pi/hotline.html",
+      "DisableAutomaticStates": true,
+      "UserTitleEnabled": false,
+      "Controllers": ["Keypad"],
+      "States": [
+        {
+          "Image": "images/actions/default",
+          "TitleAlignment": "bottom"
+        }
+      ]
+    },
+    {
+      "Name": "Push to talk",
+      "UUID": "com.neil-enns.trackaudio.pushtotalk",
+      "Icon": "images/plugin/microphone-solid",
+      "Tooltip": "Triggers transmit via push-to-talk.",
+      "SupportURL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/push-to-talk/",
+      "DisableAutomaticStates": true,
+      "UserTitleEnabled": false,
+      "PropertyInspectorPath": "pi/pushToTalk.html",
+      "Controllers": ["Keypad"],
+      "States": [
+        {
+          "Image": "images/actions/default",
+          "TitleAlignment": "middle"
+        }
+      ]
+    },
+    {
+      "Name": "Station status",
+      "UUID": "com.neil-enns.trackaudio.stationstatus",
+      "Icon": "images/plugin/headphones-solid",
+      "Tooltip": "Shows the status of a station.",
+      "SupportURL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/station-status/",
+      "DisableAutomaticStates": true,
+      "Controllers": ["Keypad"],
+      "PropertyInspectorPath": "pi/stationStatus.html",
+      "UserTitleEnabled": false,
+      "States": [
+        {
+          "Image": "images/actions/default",
+          "TitleAlignment": "middle"
+        }
+      ]
+    },
+    {
+      "Name": "TrackAudio status",
+      "UUID": "com.neil-enns.trackaudio.trackaudiostatus",
+      "Icon": "images/actions/trackAudioStatus/pluginIcon",
+      "Tooltip": "Shows the status of the connection to TrackAudio.",
+      "SupportURL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/trackaudio-status/",
+      "PropertyInspectorPath": "pi/trackAudioStatus.html",
+      "DisableAutomaticStates": true,
+      "UserTitleEnabled": false,
+      "Controllers": ["Keypad"],
+      "States": [
+        {
+          "Image": "images/actions/default",
+          "TitleAlignment": "middle"
+        }
+      ]
+    }
+  ],
+  "ApplicationsToMonitor": {
+    "mac": ["com.vatsim.trackaudio"],
+    "windows": ["trackaudio.exe"]
+  },
+  "Category": "TrackAudio",
+  "CategoryIcon": "images/plugin/categoryIcon",
+  "CodePath": "bin/plugin.js",
+  "Description": "Provides buttons for controlling TrackAudio",
+  "Icon": "images/plugin/pluginIcon",
+  "SDKVersion": 3,
+  "URL": "https://projects.neilenns.com/docs/streamdeck-trackaudio/",
+  "Software": {
+    "MinimumVersion": "6.9"
+  },
+  "OS": [
+    {
+      "Platform": "mac",
+      "MinimumVersion": "10.15"
+    },
+    {
+      "Platform": "windows",
+      "MinimumVersion": "10"
+    }
+  ],
+  "Nodejs": {
+    "Version": "20",
+    "Debug": "--inspect=127.0.0.1:54545"
+  },
+  "UUID": "com.neil-enns.trackaudio"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@elgato/streamdeck": "^1.0.0",
+        "@elgato/streamdeck": "^2.0.0-beta",
         "axios": "^1.7.2",
         "chokidar": "^4.0.0",
         "debounce": "^2.1.0",
@@ -147,18 +147,18 @@
       "license": "MIT"
     },
     "node_modules/@elgato/schemas": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@elgato/schemas/-/schemas-0.4.2.tgz",
-      "integrity": "sha512-0PT3JetTnl9xOYzHknZNJkoyGIoWMaeMh8wowSLQ0HyUg52D0HOR0ENxPnsue2ESyc9tTeThzqLcB/xEEwiSkQ==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@elgato/schemas/-/schemas-0.4.8.tgz",
+      "integrity": "sha512-9BI4cz5v3yahuoOKW6HWjfkWAV87W4fOsXUaoOUbOVHElIUNCFdEfB+tV4KTSS59OA0nu5oaaqtDhOkCy3ZIGg==",
       "license": "MIT"
     },
     "node_modules/@elgato/streamdeck": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@elgato/streamdeck/-/streamdeck-1.4.0.tgz",
-      "integrity": "sha512-VVwd+ce2Xt41TCW27TJuky5X78cI5OZcuhTUXsdfPtZ74Tjf0yo0Li5aaDUi8ew5NEsHufIWoMMZVViFkN6qLw==",
+      "version": "2.0.0-beta",
+      "resolved": "https://registry.npmjs.org/@elgato/streamdeck/-/streamdeck-2.0.0-beta.tgz",
+      "integrity": "sha512-3VxZn91PQJ9KAu6H9HzZZAxcQCBGoBBhGtqvdgJoMN4mmDp+tAAVWD2nYiHhGtGqQJ1Opcx0tXpUeLsYaffDKw==",
       "license": "MIT",
       "dependencies": {
-        "@elgato/schemas": "^0.4.1",
+        "@elgato/schemas": "^0.4.8",
         "ws": "^8.18.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript-eslint": "^8.0.0"
   },
   "dependencies": {
-    "@elgato/streamdeck": "^1.0.0",
+    "@elgato/streamdeck": "^2.0.0-beta",
     "axios": "^1.7.2",
     "chokidar": "^4.0.0",
     "debounce": "^2.1.0",


### PR DESCRIPTION
Fixes #495

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Plugin SDK bumped to version 3 for improved compatibility with the latest Stream Deck software.
  - Stream Deck dependency upgraded to v2.0.0-beta to enable newer platform capabilities.
  - No functional changes expected; existing workflows should remain unaffected.
  - Users on recent Stream Deck releases may see smoother operation; older setups might require updating their Stream Deck software.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->